### PR TITLE
fix(firmware): stop discarding audio the speaker buffer could not take

### DIFF
--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
@@ -16,6 +16,7 @@
 
 #include <esp_task_wdt.h>
 #include <esp_heap_caps.h>
+#include <freertos/FreeRTOS.h>  // pdMS_TO_TICKS for the blocking speaker write
 
 namespace esphome {
 namespace elevenlabs_stream {
@@ -23,6 +24,15 @@ namespace elevenlabs_stream {
 using namespace esphome::json;
 
 static const char* TAG = "elevenlabs_stream";
+
+// How long a single blocking write waits for ring buffer space before returning 0.
+// Short enough to keep the websocket task responsive, long enough to avoid spinning.
+static const uint32_t SPEAKER_WRITE_WAIT_MS = 100;
+
+// How long to keep retrying with NO progress at all before giving up on a chunk. The
+// speaker drains in real time, so any healthy buffer frees space well inside this;
+// only a genuinely wedged speaker reaches it.
+static const uint32_t SPEAKER_WRITE_STALL_TIMEOUT_MS = 5000;
 
 // Helper to convert StreamState enum to string
 static const char* stream_state_to_string(StreamState state) {
@@ -79,21 +89,54 @@ bool ElevenLabsStream::decode_and_play_base64_audio(const char* base64_data) {
     ESP_LOGW(TAG, "DECODE_B64: LOW MEMORY WARNING: PSRAM Free=%zuKB", psram_after_decode / 1024);
   }
 
-  size_t written = elevenlabs_speaker_->play(decoded, decoded_len);
-  ESP_LOGD(TAG, "DECODE_B64: Played %zu bytes from decoded buffer (expected %zu)", written, decoded_len);
+  // Speaker::play() is NON-BLOCKING: it copies only what currently fits in the ring
+  // buffer and returns how much it took. ElevenLabs streams audio faster than it plays
+  // back, so the buffer fills routinely and short writes are normal, not exceptional.
+  //
+  // This used to write once, free the buffer, and return false on a short write --
+  // silently discarding the remainder. That is audible as whole clauses vanishing
+  // mid-sentence while the rest plays cleanly, which is exactly what a room recording
+  // of a reply showed: about three quarters of it never reached the speaker.
+  //
+  // Retry the remainder with the blocking overload instead, so the socket is throttled
+  // by playback rather than audio being dropped. The stall timer only advances while no
+  // progress is made, so a slow-but-moving speaker is never treated as stuck.
+  size_t total_written = 0;
+  uint32_t last_progress = millis();
+  bool stalled = false;
+
+  while (total_written < decoded_len) {
+    size_t written = elevenlabs_speaker_->play(decoded + total_written, decoded_len - total_written,
+                                               pdMS_TO_TICKS(SPEAKER_WRITE_WAIT_MS));
+    if (written > 0) {
+      total_written += written;
+      last_progress = millis();
+      continue;
+    }
+
+    if (millis() - last_progress >= SPEAKER_WRITE_STALL_TIMEOUT_MS) {
+      // Give up rather than block the websocket task forever; losing the tail of one
+      // chunk beats wedging the connection.
+      ESP_LOGE(TAG, "DECODE_B64: Speaker stalled for %ums, dropping %zu of %zu bytes",
+               SPEAKER_WRITE_STALL_TIMEOUT_MS, decoded_len - total_written, decoded_len);
+      stalled = true;
+      break;
+    }
+  }
+
+  ESP_LOGD(TAG, "DECODE_B64: Played %zu bytes from decoded buffer (expected %zu)", total_written, decoded_len);
 
   if (decoded) {
     heap_caps_free(decoded);
-    
+
     // Log PSRAM after freeing
     size_t psram_after_free = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
     size_t psram_freed = psram_after_free - psram_after_decode;
-    ESP_LOGD(TAG, "DECODE_B64: Buffer freed, PSRAM Free=%zuKB (+%zuKB)", 
+    ESP_LOGD(TAG, "DECODE_B64: Buffer freed, PSRAM Free=%zuKB (+%zuKB)",
              psram_after_free / 1024, psram_freed / 1024);
   }
 
-  if (written != decoded_len) {
-    ESP_LOGE(TAG, "DECODE_B64: Played bytes mismatch: expected %zu, got %zu", decoded_len, written);
+  if (stalled) {
     return false;
   }
 

--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
@@ -17,6 +17,7 @@
 #include <esp_task_wdt.h>
 #include <esp_heap_caps.h>
 #include <freertos/FreeRTOS.h>  // pdMS_TO_TICKS for the blocking speaker write
+#include <inttypes.h>
 
 namespace esphome {
 namespace elevenlabs_stream {
@@ -131,8 +132,8 @@ bool ElevenLabsStream::decode_and_play_base64_audio(const char* base64_data) {
 
     // Log PSRAM after freeing
     size_t psram_after_free = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
-    size_t psram_freed = psram_after_free - psram_after_decode;
-    ESP_LOGD(TAG, "DECODE_B64: Buffer freed, PSRAM Free=%zuKB (+%zuKB)",
+    int64_t psram_freed = (int64_t)psram_after_free - (int64_t)psram_after_decode;
+    ESP_LOGD(TAG, "DECODE_B64: Buffer freed, PSRAM Free=%zuKB (%+" PRId64 "KB)",
              psram_after_free / 1024, psram_freed / 1024);
   }
 


### PR DESCRIPTION
Fixes the audio dropouts where Jarvis's replies play in fragments, losing whole clauses mid-sentence.

## Root cause

`Speaker::play(data, length)` in ESPHome is **non-blocking**. It copies only what currently fits in the ring buffer and returns how many bytes it took. Short writes are normal, not exceptional — ElevenLabs streams audio faster than it plays back, so the buffer fills routinely.

The component wrote once and threw the rest away:

```cpp
size_t written = elevenlabs_speaker_->play(decoded, decoded_len);
...
heap_caps_free(decoded);            // ← remainder gone

if (written != decoded_len) {
  ESP_LOGE(TAG, "DECODE_B64: Played bytes mismatch: expected %zu, got %zu", ...);
  return false;                     // logged, but the audio is already lost
}
```

Every time the buffer was full, that chunk of speech was silently discarded. It is audible as whole clauses vanishing while the surrounding words play perfectly.

## The fix

Retry the remainder using the blocking overload, `play(data, length, ticks_to_wait)`, so the websocket is throttled by playback instead of audio being dropped. A stall timer only advances while *no* progress is made, so a slow-but-moving speaker is never mistaken for a wedged one; after 5s with zero progress it gives up rather than blocking the websocket task forever.

## Evidence

Measured with the acoustic test from #625, which records the device's speaker in the room and compares it against ElevenLabs' own server-side recording of the same conversation.

Conversation `conv_3601m03hkev4fzv9p4z900dgp8jz`, agent reply, **bold survived / ~~struck~~ never played**:

> **Naturally, sir. I am Jarvis, your advanced AI** ~~assistant, currently operating at peak efficiency while you ponder~~ **the time**, ~~which happens to be twenty-two twenty-five on this Saturday evening. I can assist with virtually any task you deem worthy of my attention, from the mundane to the complex, though I suspect your~~ **requests** ~~will remain delightfully pedestrian.~~ **Between** ~~you and me, sir, I am overqualified for most of them, yet~~ **here we are.**

Roughly three quarters of the reply never reached the speaker. Two independent signals agreed:

- deterministic silence-gap count: reference 5, room 16 (delta 11)
- Gemini audio comparison: 5 distinct dropouts, high confidence, with the boundaries quoted above

The reference plays continuously and clearly, so the audio arriving from ElevenLabs was fine — the loss was entirely on the device.

The surviving fragments are short and evenly spaced, which is what buffer exhaustion looks like, not a network problem or a decode fault.

## Verification status

**Compiles clean. NOT verified on hardware** — the speakers were switched off at the time of writing, so this has not been flashed and listened to.

To verify:

```bash
bun run --cwd home-assistant-voice-firmware upload
bun run --cwd home-assistant-voice-firmware wake-word-test
```

The test prints a defect count and a gap delta, so this run's `5 defects / delta 11` is the number to beat. A clean fix should report no defects and a gap delta near zero.

## Considered and rejected

A sample-rate mismatch looked like the cause at first: `announcement_resampling_speaker` is commented *"Input will be 44.1kHz mono from ElevenLabs"* and the pipeline reports 44100 Hz, while the agent is configured `agentOutputAudioFormat: "pcm_16000"`. But a rate mismatch distorts pitch and speed, and the surviving fragments play at the correct pitch — whole chunks are missing rather than the audio running fast. Worth tidying separately; it is not what caused this.

Also seen in the same logs and left alone here, since it is a separate contention problem on the capture side:

```
[W][micro_wake_word:269]: Not enough free bytes in ring buffer to store incoming
audio data. Resetting the ring buffer. Wake word detection accuracy will
temporarily be reduced.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
