### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           # Only remove what we definitely don't need for faster cleanup
           android: false
@@ -49,7 +49,7 @@ jobs:
           swap-storage: false    # Skip swap removal to save time
 
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0  # Fetch all history for turbo affected detection to work
           # The build runs untrusted pull request code; never leave a usable
@@ -63,7 +63,7 @@ jobs:
         run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Restore Turborepo cache
-        uses: actions/cache@v5.1.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .turbo
           key: turbo-cache-${{ runner.os }}-${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
             turbo-cache-${{ runner.os }}-
 
       - name: Build and test in dev container
-        uses: devcontainers/ci@v0.3.1900000450
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Release using "Release Please"
         id: release
-        uses: googleapis/release-please-action@v4.4.1
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           # Only remove what we definitely don't need for faster cleanup
           android: false
@@ -62,7 +62,7 @@ jobs:
           swap-storage: false    # Skip swap removal to save time
 
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # The deploy runs project code and container builds; don't leave a
           # usable GitHub token behind in .git/config.
@@ -72,14 +72,14 @@ jobs:
         run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy in dev container
-        uses: devcontainers/ci@v0.3.1900000450
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,12 +28,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # Keep in sync with the `packageManager` field in package.json.
           bun-version: "1.3.9"
@@ -81,14 +81,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 
       # Blocks pull requests that introduce a dependency with a known
       # high-severity advisory or an unacceptable license.
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4.9.0
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
Fixes the supply chain policy failure on `main`.

## The failure

The `Security` workflow's `Supply chain policy` job failed with 14 violations — every `uses:` in every workflow was still on a mutable version tag:

```
❌ GitHub Actions must be pinned to a full commit SHA:
     .github/workflows/build.yml:41:  uses: jlumbroso/free-disk-space@v1.3.1
     .github/workflows/build.yml:52:  uses: actions/checkout@v6.1.0
     ... 12 more
❌ Supply chain check failed with 1 problem(s).
```

A tag can be repointed at any commit by whoever owns the action, so the code that runs tomorrow need not be the code reviewed today. A SHA cannot be moved.

## The fix

All 14 refs pinned. **Every SHA comes from `.github/workflows/actions.lock`**, which had already resolved them — so nothing is newly trusted here, the same commits the lockfile pinned are simply named directly in the workflows now. The version tag is kept as a trailing comment so the files stay readable and Dependabot can still recognise and bump them:

```diff
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
```

## Verification

Ran the repo's own checker, `.scripts/check-supply-chain.sh` — **all 11 checks pass**, including the one that was failing:

```
✅ All GitHub Actions are pinned to commit SHAs
✅ Supply chain check passed.
```

All three workflows still parse as valid YAML.

## Not covered by this PR

The `CodeQL` run also shows a `startup_failure` with a *different* error:

```
Workflow must use a lockfile. Run `gh actions pin <workflow-path>` to generate one.
The following workflows are missing a lockfile:
  - .github/workflows/build.yml
```

That one is a **dynamically generated** workflow (`event: dynamic`) from CodeQL's default setup, so there is no file in this repo to pin, and it needs a separate decision — most likely switching CodeQL from default setup to an advanced setup with a committed workflow file, which `actions.lock` would then cover. Left alone rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5