### PR TITLE
ci: pin actions by tag and let the lockfile hold the SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           # Only remove what we definitely don't need for faster cleanup
           android: false
@@ -49,7 +49,7 @@ jobs:
           swap-storage: false    # Skip swap removal to save time
 
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 0  # Fetch all history for turbo affected detection to work
           # The build runs untrusted pull request code; never leave a usable
@@ -63,7 +63,7 @@ jobs:
         run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Restore Turborepo cache
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: actions/cache@v5.1.0
         with:
           path: .turbo
           key: turbo-cache-${{ runner.os }}-${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
             turbo-cache-${{ runner.os }}-
 
       - name: Build and test in dev container
-        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
+        uses: devcontainers/ci@v0.3.1900000450
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Release using "Release Please"
         id: release
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        uses: googleapis/release-please-action@v4.4.1
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           # Only remove what we definitely don't need for faster cleanup
           android: false
@@ -62,7 +62,7 @@ jobs:
           swap-storage: false    # Skip swap removal to save time
 
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6.1.0
         with:
           # The deploy runs project code and container builds; don't leave a
           # usable GitHub token behind in .git/config.
@@ -72,14 +72,14 @@ jobs:
         run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy in dev container
-        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
+        uses: devcontainers/ci@v0.3.1900000450
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,12 +28,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           # Keep in sync with the `packageManager` field in package.json.
           bun-version: "1.3.9"
@@ -81,14 +81,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6.1.0
         with:
           persist-credentials: false
 
       # Blocks pull requests that introduce a dependency with a known
       # high-severity advisory or an unacceptable license.
       - name: Review dependency changes
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@v4.9.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.scripts/check-supply-chain.sh
+++ b/.scripts/check-supply-chain.sh
@@ -99,17 +99,44 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 4. GitHub Actions are pinned to immutable commit SHAs.
+# 4. Every GitHub Action is pinned to an immutable commit SHA by the lockfile.
 # ---------------------------------------------------------------------------
-unpinned_actions=$(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml' |
-	xargs grep -nE '^[[:space:]]*(-[[:space:]]*)?uses:' 2>/dev/null |
-	grep -vE 'uses:[[:space:]]*\./' |
-	grep -vE 'uses:[[:space:]]*[^@]+@[0-9a-f]{40}([[:space:]]|$|#)' || true)
-if [ -n "$unpinned_actions" ]; then
-	fail "GitHub Actions must be pinned to a full commit SHA:"
-	echo "$unpinned_actions" | sed 's/^/     /'
+# The pinning lives in .github/workflows/actions.lock, not inline in the workflows.
+# GitHub resolves each `uses:` through that lockfile, so a tag reference still runs
+# the exact commit recorded there, and a hijacked tag is caught before it runs.
+#
+# This check used to demand a bare SHA on every `uses:` line instead. That is
+# actively worse under the lockfile model: `gh actions-lock` reports a bare SHA as
+# "pinned to a bare SHA without a symbolic ref — weakens supply-chain traceability",
+# because the SHA alone says nothing about which release it is. Worse, rewriting the
+# workflows to SHAs desynchronised them from the lockfile, which GitHub then rejected
+# outright with "Invalid lockfile: the lockfile could not be validated" -- a startup
+# failure that stopped every workflow from running at all.
+#
+# So verify what actually matters: the lockfile exists, and it accounts for every
+# action referenced by every workflow. Deliberately offline and dependency-free --
+# `gh actions-lock --no-fix` is the richer check, but it needs the extension and
+# network access, and this script must stay runnable anywhere.
+actions_lock='.github/workflows/actions.lock'
+if [ ! -f "$actions_lock" ]; then
+	fail "Missing $actions_lock — generate it with: gh actions-lock"
 else
-	pass "All GitHub Actions are pinned to commit SHAs"
+	unlocked_actions=$(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml' |
+		xargs grep -nE '^[[:space:]]*(-[[:space:]]*)?uses:' 2>/dev/null |
+		grep -vE 'uses:[[:space:]]*\./' |
+		while IFS= read -r line; do
+			# "path:lineno:  uses: owner/repo@ref  # comment" -> "owner/repo@ref"
+			ref=$(printf '%s\n' "$line" | sed -E 's/.*uses:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+			# A ref already pinned to a bare SHA needs no lockfile entry to be immutable.
+			printf '%s\n' "$ref" | grep -qE '@[0-9a-f]{40}$' && continue
+			grep -qF "'${ref}'" "$actions_lock" || printf '%s\n' "$line"
+		done)
+	if [ -n "$unlocked_actions" ]; then
+		fail "GitHub Actions missing from $actions_lock (run: gh actions-lock):"
+		echo "$unlocked_actions" | sed 's/^/     /'
+	else
+		pass "All GitHub Actions are pinned via $actions_lock"
+	fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the `Invalid lockfile` startup failure on `main`, and reconciles the two policies that were pulling against each other.

## What went wrong

#653 (mine) rewrote every `uses:` to a bare commit SHA to satisfy `check-supply-chain.sh`. That desynchronised the workflows from `.github/workflows/actions.lock`, which still described them by tag, so GitHub rejected the lockfile:

```
Invalid lockfile: .github/workflows/actions.lock
The lockfile could not be validated. Regenerate it by running `gh actions-lock`.
```

That's a **startup failure** — no workflow ran at all. Strictly worse than the failing check it was meant to fix. My apologies; I should have checked how the lockfile and the script interacted before changing either.

## Bare SHAs are the wrong answer here

`gh actions-lock` flags every one of them:

> `sha-as-ref` — "pinned to a bare SHA without a symbolic ref — weakens supply-chain traceability"
> remediation: "pin to a tag instead"

Under the lockfile model the **lockfile** pins the commit; the **tag** keeps the diff readable and lets Dependabot recognise the dependency. A bare SHA gives up the second without gaining anything on the first.

## The fix

**Workflows go back to tags** — reverted by `gh actions-lock` itself, not by hand.

**`check-supply-chain.sh` now verifies what actually matters**: that the lockfile exists and accounts for every action every workflow references. A ref already pinned to a bare SHA is still accepted, since it's immutable regardless.

The new check is deliberately offline and dependency-free. `gh actions-lock --no-fix` is the richer validation, but it needs the extension plus network access, and this script has to stay runnable anywhere.

## Verification

| | before | after |
|---|---|---|
| `gh actions-lock --no-fix` | valid, **14 sha-as-ref warnings** | **valid, 0 warnings** |
| `check-supply-chain.sh` | ❌ failed | ✅ **all 11 checks pass** |

And the new check isn't a rubber stamp — I injected `evil/rogue-action@v9.9.9` into `security.yml` and confirmed it's caught:

```
❌ GitHub Actions missing from .github/workflows/actions.lock (run: gh actions-lock):
     .github/workflows/security.yml:31:        uses: evil/rogue-action@v9.9.9
```

…then passes again once restored.

`actions.lock` itself is **unchanged** — it was correct all along; the workflows were what drifted.

## Still open

The `CodeQL` `startup_failure` is separate: it's a dynamically generated default-setup workflow (`event: dynamic`) with no file in this repo to lock. Likely needs converting to an advanced setup with a committed workflow file, which `actions.lock` would then cover — a repo-settings decision, so left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5