### PR TITLE
feat(firmware): proactive announcements with a VAD-timed silence window

### DIFF
--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
@@ -308,13 +308,6 @@ void ElevenLabsStream::setup() {
       ESP_LOGI(TAG, "SPEAKER_CALLBACK: Setting speaker_is_active_ = false");
       this->speaker_is_active_ = false;
 
-      // The agent has stopped talking. If this conversation has a response window and
-      // nobody has spoken yet, start counting from here -- the window is meant to
-      // measure silence after the announcement, not from when it began.
-      if (this->response_window_ms_ > 0 && !this->user_responded_ && this->awaiting_response_since_ == 0) {
-        this->awaiting_response_since_ = millis();
-        ESP_LOGI(TAG, "SPEAKER_CALLBACK: Listening %ums for a reply", this->response_window_ms_);
-      }
 
       for (auto *trigger : this->on_listening_triggers_) {
           trigger->trigger();
@@ -381,27 +374,14 @@ void ElevenLabsStream::loop() {
     last_psram_log = millis();
   }
   
-  // Close an unanswered announcement.
-  //
-  // The window opens when the agent stops speaking (see the speaker callback) and is
-  // cancelled by a real user_transcript. If it expires, nobody replied, so end the
-  // conversation rather than hold the microphone open indefinitely.
-  //
-  // This replaces a check against last_user_input_time_, which could never fire: that
-  // timestamp is refreshed on every outgoing microphone chunk, and the microphone
-  // streams continuously while the stream is open, so "time since last input" was
-  // always ~0 no matter whether anyone had spoken.
-  if (this->response_window_ms_ > 0 && this->state_ == StreamState::ON &&
-      this->awaiting_response_since_ > 0 && !this->user_responded_ && !this->speaker_is_active_) {
-    uint32_t waited = millis() - this->awaiting_response_since_;
-    if (waited >= this->response_window_ms_) {
-      ESP_LOGI(TAG, "LOOP: No reply within %ums of the announcement finishing; ending the conversation",
-               this->response_window_ms_);
-      this->stop_stream();
-      return;
-    }
-  }
-  
+  // NOTE: silence is no longer timed here. ElevenLabs ends the call itself via the
+  // silence_end_call_timeout override sent at conversation start -- see
+  // send_conversation_init(). A local timer was tried first and could not work: it was
+  // driven by last_user_input_time_, which is stamped on every outgoing microphone
+  // chunk, and the microphone streams continuously while the stream is open. "Time
+  // since last input" was therefore always about zero regardless of whether anyone had
+  // spoken, so the timeout never fired.
+
   // Send periodic heartbeat when connected
   if (this->client_ && this->state_ == StreamState::ON && !this->speaker_is_active_) {
     uint32_t heartbeat_elapsed = millis() - this->last_heartbeat_;
@@ -435,11 +415,10 @@ bool ElevenLabsStream::start_stream(const std::string &initial_message, uint32_t
   this->conversation_timeout_ms_ = timeout_ms;
   this->last_user_input_time_ = 0; // Reset on new stream
 
-  // timeout_ms is the announcement response window. Wake-word conversations pass 0 and
-  // stay open as before; only a proactive announcement asks to close itself.
-  this->response_window_ms_ = timeout_ms;
-  this->awaiting_response_since_ = 0;
-  this->user_responded_ = false;
+  // timeout_ms is milliseconds of silence to allow before ElevenLabs ends the call.
+  // Converted to whole seconds because that is the unit the override takes; anything
+  // under a second rounds up so a small value cannot silently become "no timeout".
+  this->silence_timeout_s_ = timeout_ms > 0 ? ((timeout_ms + 999) / 1000) : 0;
 
   this->connection_start_time_ = millis();
   ESP_LOGD(TAG, "START_STREAM: Connection start time set to %d", this->connection_start_time_);
@@ -888,15 +867,6 @@ void ElevenLabsStream::parse_json_message_from_buffer(uint8_t *buffer, size_t le
       const char* user_transcript = transcript["user_transcript"];
       if (user_transcript) {
         ESP_LOGI(TAG, "PARSE_JSON_BUF: User transcript: '%s'", user_transcript);
-
-        // Somebody actually spoke, so this is a conversation now rather than an
-        // unanswered announcement. Cancel the window permanently: reopening it after
-        // each later reply would cut a real exchange short after one pause.
-        if (!this->user_responded_) {
-          this->user_responded_ = true;
-          this->awaiting_response_since_ = 0;
-          ESP_LOGI(TAG, "PARSE_JSON_BUF: Reply received; the announcement window no longer applies");
-        }
         // Could trigger an event here for transcript handling
       } else {
         ESP_LOGW(TAG, "PARSE_JSON_BUF: No user_transcript in user_transcription_event");
@@ -1063,6 +1033,21 @@ void ElevenLabsStream::send_conversation_init() {
     // Language configuration
     // Use custom initial message if provided, otherwise use empty string
     agent["first_message"] = this->initial_message_.empty() ? "" : this->initial_message_.c_str();
+
+    // Let ElevenLabs end the call on silence rather than timing it here.
+    //
+    // The service already knows when a user is speaking -- it runs the turn model and
+    // the transcriber -- so it can tell a pause from a reply. The device only sees a
+    // continuous microphone stream and would have to guess. Overriding
+    // silence_end_call_timeout puts the decision where the information is.
+    //
+    // Only sent when a window was requested; a wake-word conversation leaves the
+    // agent's configured default (30s) alone.
+    if (this->silence_timeout_s_ > 0) {
+      JsonObject turn = conversation_config["turn"].to<JsonObject>();
+      turn["silence_end_call_timeout"] = this->silence_timeout_s_;
+      ESP_LOGI(TAG, "SEND_CONV_INIT: Overriding silence_end_call_timeout to %us", this->silence_timeout_s_);
+    }
   });
   
   ESP_LOGD(TAG, "SEND_CONV_INIT: Sending conversation init: %s", message.c_str());

--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
@@ -308,6 +308,14 @@ void ElevenLabsStream::setup() {
       ESP_LOGI(TAG, "SPEAKER_CALLBACK: Setting speaker_is_active_ = false");
       this->speaker_is_active_ = false;
 
+      // The agent has stopped talking. If this conversation has a response window and
+      // nobody has spoken yet, start counting from here -- the window is meant to
+      // measure silence after the announcement, not from when it began.
+      if (this->response_window_ms_ > 0 && !this->user_responded_ && this->awaiting_response_since_ == 0) {
+        this->awaiting_response_since_ = millis();
+        ESP_LOGI(TAG, "SPEAKER_CALLBACK: Listening %ums for a reply", this->response_window_ms_);
+      }
+
       for (auto *trigger : this->on_listening_triggers_) {
           trigger->trigger();
       }
@@ -373,12 +381,22 @@ void ElevenLabsStream::loop() {
     last_psram_log = millis();
   }
   
-  // Check for conversation timeout if configured
-  if (this->conversation_timeout_ms_ > 0 && this->state_ == StreamState::ON && 
-      this->last_user_input_time_ > 0 && !this->speaker_is_active_) {
-    uint32_t time_since_input = millis() - this->last_user_input_time_;
-    if (time_since_input >= this->conversation_timeout_ms_) {
-      ESP_LOGI(TAG, "LOOP: Conversation timeout reached (%u ms since last input), stopping stream", time_since_input);
+  // Close an unanswered announcement.
+  //
+  // The window opens when the agent stops speaking (see the speaker callback) and is
+  // cancelled by a real user_transcript. If it expires, nobody replied, so end the
+  // conversation rather than hold the microphone open indefinitely.
+  //
+  // This replaces a check against last_user_input_time_, which could never fire: that
+  // timestamp is refreshed on every outgoing microphone chunk, and the microphone
+  // streams continuously while the stream is open, so "time since last input" was
+  // always ~0 no matter whether anyone had spoken.
+  if (this->response_window_ms_ > 0 && this->state_ == StreamState::ON &&
+      this->awaiting_response_since_ > 0 && !this->user_responded_ && !this->speaker_is_active_) {
+    uint32_t waited = millis() - this->awaiting_response_since_;
+    if (waited >= this->response_window_ms_) {
+      ESP_LOGI(TAG, "LOOP: No reply within %ums of the announcement finishing; ending the conversation",
+               this->response_window_ms_);
       this->stop_stream();
       return;
     }
@@ -416,6 +434,12 @@ bool ElevenLabsStream::start_stream(const std::string &initial_message, uint32_t
   this->initial_message_ = initial_message;
   this->conversation_timeout_ms_ = timeout_ms;
   this->last_user_input_time_ = 0; // Reset on new stream
+
+  // timeout_ms is the announcement response window. Wake-word conversations pass 0 and
+  // stay open as before; only a proactive announcement asks to close itself.
+  this->response_window_ms_ = timeout_ms;
+  this->awaiting_response_since_ = 0;
+  this->user_responded_ = false;
 
   this->connection_start_time_ = millis();
   ESP_LOGD(TAG, "START_STREAM: Connection start time set to %d", this->connection_start_time_);
@@ -864,6 +888,15 @@ void ElevenLabsStream::parse_json_message_from_buffer(uint8_t *buffer, size_t le
       const char* user_transcript = transcript["user_transcript"];
       if (user_transcript) {
         ESP_LOGI(TAG, "PARSE_JSON_BUF: User transcript: '%s'", user_transcript);
+
+        // Somebody actually spoke, so this is a conversation now rather than an
+        // unanswered announcement. Cancel the window permanently: reopening it after
+        // each later reply would cut a real exchange short after one pause.
+        if (!this->user_responded_) {
+          this->user_responded_ = true;
+          this->awaiting_response_since_ = 0;
+          ESP_LOGI(TAG, "PARSE_JSON_BUF: Reply received; the announcement window no longer applies");
+        }
         // Could trigger an event here for transcript handling
       } else {
         ESP_LOGW(TAG, "PARSE_JSON_BUF: No user_transcript in user_transcription_event");

--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.cpp
@@ -67,6 +67,14 @@ static const uint32_t REPLY_PREBUFFER_MAX_MS = 400;
 // How long to let a short reply finish playing before the speaker is stopped.
 static const uint32_t SPEAKER_DRAIN_TIMEOUT_MS = 3000;
 
+// vad_score above which an announcement treats the room as occupied and keeps waiting.
+// The service documents the score as the probability that the user is speaking, so this
+// is "more likely than not". See the VAD handler for why it sits above the LED's 0.25.
+static const float ANNOUNCEMENT_SPEECH_THRESHOLD = 0.5f;
+
+// How long an announcement waits for the agent's first audio before giving up on it.
+static const uint32_t ANNOUNCEMENT_FIRST_AUDIO_TIMEOUT_MS = 20000;
+
 // Helper to convert StreamState enum to string
 static const char* stream_state_to_string(StreamState state) {
   switch (state) {
@@ -99,6 +107,12 @@ bool ElevenLabsStream::decode_and_play_base64_audio(const char* base64_data) {
     ESP_LOGW(TAG, "DECODE_B64: Input base64 string is empty");
     return false;
   }
+
+  // Both audio paths -- the fast path and the JSON one -- come through here, so this is
+  // the one place that knows the agent has started talking. Until it does, an
+  // announcement's reply window must stay shut: connecting, fetching a signed URL and
+  // synthesising the first message can easily outlast three seconds of "silence".
+  this->agent_has_spoken_ = true;
 
   // Log PSRAM before decode
   size_t psram_before_decode = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
@@ -374,13 +388,53 @@ void ElevenLabsStream::loop() {
     last_psram_log = millis();
   }
   
-  // NOTE: silence is no longer timed here. ElevenLabs ends the call itself via the
-  // silence_end_call_timeout override sent at conversation start -- see
-  // send_conversation_init(). A local timer was tried first and could not work: it was
-  // driven by last_user_input_time_, which is stamped on every outgoing microphone
-  // chunk, and the microphone streams continuously while the stream is open. "Time
-  // since last input" was therefore always about zero regardless of whether anyone had
-  // spoken, so the timeout never fired.
+  // An announcement hangs up if nobody answers it.
+  //
+  // The clock is held at zero, rather than merely reset, for as long as there is any
+  // reason to believe the exchange is still alive: the agent has yet to say anything,
+  // its audio is still playing, or the speaker has only just fallen quiet. It starts
+  // running at the first moment none of that is true, and vad_score pushes it back
+  // whenever the service thinks it can hear somebody (see parse_json_buffer). So the
+  // window measures silence in the room after the announcement, which is the thing
+  // actually being asked about.
+  if (this->awaiting_response_ && this->response_window_ms_ > 0 && this->state_ == StreamState::ON) {
+    // Nothing else bounds an announcement that never gets off the ground -- if the agent
+    // produces no audio at all, "the agent is still busy" stays true forever and the
+    // socket is left open on a conversation nobody in the room is aware of. The bound is
+    // loose on purpose: it has to cover the signed URL round trip, the LLM and the first
+    // sentence of speech, and it only exists to catch outright failure.
+    if (!this->agent_has_spoken_ &&
+        millis() - this->connection_start_time_ >= ANNOUNCEMENT_FIRST_AUDIO_TIMEOUT_MS) {
+      ESP_LOGW(TAG, "LOOP: Announcement produced no audio within %ums, ending conversation",
+               ANNOUNCEMENT_FIRST_AUDIO_TIMEOUT_MS);
+      this->awaiting_response_ = false;
+      this->silence_started_ms_ = 0;
+      this->stop_stream();
+      return;
+    }
+
+    const bool agent_busy = !this->agent_has_spoken_ || this->speaker_is_active_ ||
+                            // has_buffered_data(), not is_running(): the speaker is
+                            // started once for the whole conversation and only stopped
+                            // at the end, so is_running() would be true throughout and
+                            // the clock would never get to start.
+                            (this->elevenlabs_speaker_ != nullptr &&
+                             this->elevenlabs_speaker_->has_buffered_data());
+    if (agent_busy) {
+      this->silence_started_ms_ = 0;
+    } else if (this->silence_started_ms_ == 0) {
+      this->silence_started_ms_ = millis();
+      ESP_LOGD(TAG, "LOOP: Room is quiet, giving a reply %ums before hanging up",
+               this->response_window_ms_);
+    } else if (millis() - this->silence_started_ms_ >= this->response_window_ms_) {
+      ESP_LOGI(TAG, "LOOP: No reply within %ums of the announcement, ending conversation",
+               this->response_window_ms_);
+      this->awaiting_response_ = false;
+      this->silence_started_ms_ = 0;
+      this->stop_stream();
+      return;
+    }
+  }
 
   // Send periodic heartbeat when connected
   if (this->client_ && this->state_ == StreamState::ON && !this->speaker_is_active_) {
@@ -410,15 +464,12 @@ bool ElevenLabsStream::start_stream(const std::string &initial_message, uint32_t
   ESP_LOGD(TAG, "START_STREAM: Agent ID='%s'", this->agent_id_.c_str());
   ESP_LOGD(TAG, "START_STREAM: Initial message='%s', timeout=%u ms", initial_message.c_str(), timeout_ms);
 
-  // Store the initial message and timeout for this session
+  // Store the initial message and response window for this session
   this->initial_message_ = initial_message;
-  this->conversation_timeout_ms_ = timeout_ms;
-  this->last_user_input_time_ = 0; // Reset on new stream
-
-  // timeout_ms is milliseconds of silence to allow before ElevenLabs ends the call.
-  // Converted to whole seconds because that is the unit the override takes; anything
-  // under a second rounds up so a small value cannot silently become "no timeout".
-  this->silence_timeout_s_ = timeout_ms > 0 ? ((timeout_ms + 999) / 1000) : 0;
+  this->response_window_ms_ = timeout_ms;
+  this->awaiting_response_ = timeout_ms > 0;
+  this->agent_has_spoken_ = false;
+  this->silence_started_ms_ = 0;
 
   this->connection_start_time_ = millis();
   ESP_LOGD(TAG, "START_STREAM: Connection start time set to %d", this->connection_start_time_);
@@ -547,6 +598,13 @@ void ElevenLabsStream::stop_stream() {
   this->speaker_end_time_ = 0;
   this->accumulated_duration_ms_ = 0;
   ESP_LOGD(TAG, "STOP_STREAM: Speaker activity tracking reset");
+
+  // Clear the announcement window too, so a conversation started afterwards by the wake
+  // word cannot inherit a stale one and hang itself up mid-sentence.
+  this->awaiting_response_ = false;
+  this->agent_has_spoken_ = false;
+  this->silence_started_ms_ = 0;
+  this->response_window_ms_ = 0;
   
   // Disconnect WebSocket client
   if (this->client_) {
@@ -867,7 +925,17 @@ void ElevenLabsStream::parse_json_message_from_buffer(uint8_t *buffer, size_t le
       const char* user_transcript = transcript["user_transcript"];
       if (user_transcript) {
         ESP_LOGI(TAG, "PARSE_JSON_BUF: User transcript: '%s'", user_transcript);
-        // Could trigger an event here for transcript handling
+
+        // Somebody answered the announcement, so stop policing it. A transcript is the
+        // one unambiguous signal available -- vad_score only ever says something
+        // speech-shaped was heard -- and past this point the exchange is an ordinary
+        // conversation that should live or die by the agent's own settings, not by a
+        // three second window meant to catch an empty room.
+        if (this->awaiting_response_ && user_transcript[0] != '\0') {
+          ESP_LOGI(TAG, "PARSE_JSON_BUF: Announcement was answered, dropping the reply window");
+          this->awaiting_response_ = false;
+          this->silence_started_ms_ = 0;
+        }
       } else {
         ESP_LOGW(TAG, "PARSE_JSON_BUF: No user_transcript in user_transcription_event");
       }
@@ -921,8 +989,22 @@ void ElevenLabsStream::parse_json_message_from_buffer(uint8_t *buffer, size_t le
 
       this->last_vad_score_ = vad_score;
 
+      // Hold off the announcement hang-up while the service thinks it can hear someone.
+      //
+      // Deliberately a stricter threshold than the ring's 0.25. The LED is meant to be
+      // twitchy -- lighting up early feels responsive and costs nothing if it is wrong
+      // -- but the same twitchiness applied here would let a fridge hum or a passing car
+      // hold the call open indefinitely. This only needs to catch a person starting to
+      // answer, and a false negative merely ends a conversation nobody was having.
+      if (this->awaiting_response_ && vad_score >= ANNOUNCEMENT_SPEECH_THRESHOLD) {
+        if (this->silence_started_ms_ != 0) {
+          ESP_LOGD(TAG, "PARSE_JSON_BUF: Speech detected (VAD %.2f), holding the announcement open",
+                   vad_score);
+        }
+        this->silence_started_ms_ = 0;
+      }
+
       ESP_LOGD(TAG, "PARSE_JSON_BUF: VAD score: %.2f", vad_score);
-      // Could use this for voice activity detection
     } else {
       ESP_LOGD(TAG, "PARSE_JSON_BUF: No vad_score_event found");
     }
@@ -1034,20 +1116,11 @@ void ElevenLabsStream::send_conversation_init() {
     // Use custom initial message if provided, otherwise use empty string
     agent["first_message"] = this->initial_message_.empty() ? "" : this->initial_message_.c_str();
 
-    // Let ElevenLabs end the call on silence rather than timing it here.
-    //
-    // The service already knows when a user is speaking -- it runs the turn model and
-    // the transcriber -- so it can tell a pause from a reply. The device only sees a
-    // continuous microphone stream and would have to guess. Overriding
-    // silence_end_call_timeout puts the decision where the information is.
-    //
-    // Only sent when a window was requested; a wake-word conversation leaves the
-    // agent's configured default (30s) alone.
-    if (this->silence_timeout_s_ > 0) {
-      JsonObject turn = conversation_config["turn"].to<JsonObject>();
-      turn["silence_end_call_timeout"] = this->silence_timeout_s_;
-      ESP_LOGI(TAG, "SEND_CONV_INIT: Overriding silence_end_call_timeout to %us", this->silence_timeout_s_);
-    }
+    // Nothing about the silence window is sent here. turn.silence_end_call_timeout is
+    // not in the overridable set, and ElevenLabs errors a conversation that arrives with
+    // an override it does not accept -- so asking for it would not merely be ignored, it
+    // would take the announcement down with it. The window is timed on the device
+    // instead, off the vad_score events the agent already sends. See loop().
   });
   
   ESP_LOGD(TAG, "SEND_CONV_INIT: Sending conversation init: %s", message.c_str());
@@ -1175,10 +1248,11 @@ void ElevenLabsStream::handle_microphone_data(const std::vector<uint8_t> &data) 
   
   if (!this->send_websocket_message(message)) {
     ESP_LOGW(TAG, "HANDLE_MIC: Failed to send audio message via websocket");
-  } else {
-    // Update last user input time when audio is successfully sent
-    this->last_user_input_time_ = millis();
   }
+  // Nothing is stamped here on success. A timestamp taken at this point only records
+  // that the microphone is streaming, which it does continuously from the moment the
+  // socket opens -- it says nothing about whether anyone spoke. Treating it as "last
+  // user input" is what made the original silence timeout never fire.
 }
 
 void ElevenLabsStream::set_state(StreamState new_state) {

--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.h
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.h
@@ -105,15 +105,12 @@ public:
   uint32_t conversation_timeout_ms_{0}; // Timeout in milliseconds (0 = no timeout)
   uint32_t last_user_input_time_{0}; // Track last user input for timeout detection
 
-  // Proactive announcement support.
-  //
-  // An announcement speaks first, then listens briefly in case the user replies. These
-  // track that window. Deliberately separate from last_user_input_time_, which is
-  // stamped on every outgoing microphone chunk and therefore never stops advancing
-  // while the stream is open -- it cannot express "the user has not said anything".
-  uint32_t response_window_ms_{0};        // 0 = stay open indefinitely
-  uint32_t awaiting_response_since_{0};   // 0 = not currently counting down
-  bool user_responded_{false};            // set by a real user_transcript event
+  // Seconds of silence to allow before ElevenLabs ends the call, sent as a
+  // silence_end_call_timeout override at conversation start. 0 leaves the agent's own
+  // configured value alone. The device does not time this itself: it only sees a
+  // continuous microphone stream and cannot tell a pause from a reply, whereas the
+  // service is already running the turn model and the transcriber.
+  uint32_t silence_timeout_s_{0};
 
   // Triggers - simplified
   std::vector<Trigger<> *> on_start_triggers_;

--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.h
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.h
@@ -44,7 +44,6 @@ public:
   void set_elevenlabs_speaker(speaker::Speaker *speaker) { this->elevenlabs_speaker_ = speaker; }
   void set_activation_speaker(speaker::Speaker *speaker) { this->activation_speaker_ = speaker; }
   void set_initial_message(const std::string &message) { this->initial_message_ = message; }
-  void set_conversation_timeout(uint32_t timeout_ms) { this->conversation_timeout_ms_ = timeout_ms; }
 
   bool start_stream();
   bool start_stream(const std::string &initial_message);
@@ -102,15 +101,33 @@ public:
   
   // Notification/proactive message support
   std::string initial_message_; // Custom initial message for proactive notifications
-  uint32_t conversation_timeout_ms_{0}; // Timeout in milliseconds (0 = no timeout)
-  uint32_t last_user_input_time_{0}; // Track last user input for timeout detection
 
-  // Seconds of silence to allow before ElevenLabs ends the call, sent as a
-  // silence_end_call_timeout override at conversation start. 0 leaves the agent's own
-  // configured value alone. The device does not time this itself: it only sees a
-  // continuous microphone stream and cannot tell a pause from a reply, whereas the
-  // service is already running the turn model and the transcriber.
-  uint32_t silence_timeout_s_{0};
+  // How long an announcement waits for a reply before hanging up, and the state used to
+  // time it. 0 disables the whole mechanism, which is what wake-word conversations use:
+  // somebody said the wake word, so they are already talking and the call should live as
+  // long as the agent's own settings allow.
+  //
+  // Timed here rather than by the service, because silence_end_call_timeout is not an
+  // overridable field -- the overridable set is prompt, first_message, language, LLM,
+  // tool_ids, knowledge_base, the TTS voice settings, text_only and asr.keywords -- and
+  // ElevenLabs errors the conversation outright when it is sent one that is not enabled.
+  //
+  // The earlier local attempt failed for a different reason: it timed the gap between
+  // outgoing microphone chunks, and the microphone streams continuously while the socket
+  // is open, so the gap was always about zero. The signal it needed was already arriving
+  // and being ignored -- vad_score, the service's own estimate of whether a person is
+  // speaking, which the LED ring has been driven from all along.
+  uint32_t response_window_ms_{0};
+  // True while an announcement is still waiting to hear a reply. Cleared for good by the
+  // first real transcript: from then on somebody is in the conversation and the window
+  // has served its purpose.
+  bool awaiting_response_{false};
+  // True once the agent has produced audio in this stream. The clock must not run before
+  // that, or the window expires while the announcement is still being synthesised.
+  bool agent_has_spoken_{false};
+  // Start of the current unbroken run of silence, refreshed by speech and by the agent's
+  // own playback. 0 means the clock is not running.
+  uint32_t silence_started_ms_{0};
 
   // Triggers - simplified
   std::vector<Trigger<> *> on_start_triggers_;

--- a/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.h
+++ b/home-assistant-voice-firmware/components/elevenlabs_stream/elevenlabs_stream.h
@@ -105,6 +105,16 @@ public:
   uint32_t conversation_timeout_ms_{0}; // Timeout in milliseconds (0 = no timeout)
   uint32_t last_user_input_time_{0}; // Track last user input for timeout detection
 
+  // Proactive announcement support.
+  //
+  // An announcement speaks first, then listens briefly in case the user replies. These
+  // track that window. Deliberately separate from last_user_input_time_, which is
+  // stamped on every outgoing microphone chunk and therefore never stops advancing
+  // while the stream is open -- it cannot express "the user has not said anything".
+  uint32_t response_window_ms_{0};        // 0 = stay open indefinitely
+  uint32_t awaiting_response_since_{0};   // 0 = not currently counting down
+  bool user_responded_{false};            // set by a real user_transcript event
+
   // Triggers - simplified
   std::vector<Trigger<> *> on_start_triggers_;
   std::vector<Trigger<> *> on_end_triggers_;

--- a/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
+++ b/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
@@ -129,19 +129,25 @@ logger:
 api:
   id: api_id
   services:
-    # Proactive announcement: the device speaks first, then listens briefly in case
-    # the user answers. If nobody does, the conversation closes itself.
+    # Proactive announcement. The device speaks the message, then stays in a normal
+    # conversation until the user has been silent for silence_seconds.
     #
     #   service: esphome.<device>_announce
     #   data:
     #     message: "Your laundry is finished."
+    #     silence_seconds: 3
     #
-    # The 3s window is measured from the moment the announcement STOPS speaking, not
-    # from when it starts, so a long message does not eat into the reply time. Any real
-    # reply cancels the window and the conversation continues normally.
+    # The silence is timed by ElevenLabs, not here: it is sent as a
+    # silence_end_call_timeout override when the conversation opens. The service is
+    # already running the turn model and the transcriber, so it can tell a pause from a
+    # reply; the device only sees a continuous microphone stream and would be guessing.
+    #
+    # Answer and the conversation simply continues as a normal one. Say nothing and it
+    # closes itself.
     - service: announce
       variables:
         message: string
+        silence_seconds: int
       then:
         - if:
             condition:
@@ -149,37 +155,14 @@ api:
             then:
               - elevenlabs_stream.start:
                   initial_message: !lambda 'return message;'
-                  timeout: !lambda 'return 3000;'
+                  # start_stream takes milliseconds; it converts to whole seconds for
+                  # the override. Fall back to 3s if the caller passes 0 or omits it,
+                  # so an announcement can never inherit the agent's 30s default and
+                  # sit with the microphone open.
+                  timeout: !lambda 'return silence_seconds > 0 ? silence_seconds * 1000 : 3000;'
             else:
               - logger.log: "Announcement suppressed: the device is muted"
 
-    # Same, with an explicit window. timeout is milliseconds of silence to allow after
-    # the announcement finishes; 0 keeps the conversation open indefinitely, matching
-    # wake-word behaviour.
-    - service: announce_with_timeout
-      variables:
-        message: string
-        timeout: int
-      then:
-        - if:
-            condition:
-              switch.is_off: master_mute_switch
-            then:
-              - elevenlabs_stream.start:
-                  initial_message: !lambda 'return message;'
-                  timeout: !lambda 'return timeout;'
-            else:
-              - logger.log: "Announcement suppressed: the device is muted"
-
-    # Retained under its original name so existing automations keep working.
-    - service: send_notification
-      variables:
-        message: string
-        timeout: int
-      then:
-        - elevenlabs_stream.start:
-            initial_message: !lambda 'return message;'
-            timeout: !lambda 'return timeout;'
 
 json:
 

--- a/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
+++ b/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
@@ -129,6 +129,49 @@ logger:
 api:
   id: api_id
   services:
+    # Proactive announcement: the device speaks first, then listens briefly in case
+    # the user answers. If nobody does, the conversation closes itself.
+    #
+    #   service: esphome.<device>_announce
+    #   data:
+    #     message: "Your laundry is finished."
+    #
+    # The 3s window is measured from the moment the announcement STOPS speaking, not
+    # from when it starts, so a long message does not eat into the reply time. Any real
+    # reply cancels the window and the conversation continues normally.
+    - service: announce
+      variables:
+        message: string
+      then:
+        - if:
+            condition:
+              switch.is_off: master_mute_switch
+            then:
+              - elevenlabs_stream.start:
+                  initial_message: !lambda 'return message;'
+                  timeout: !lambda 'return 3000;'
+            else:
+              - logger.log: "Announcement suppressed: the device is muted"
+
+    # Same, with an explicit window. timeout is milliseconds of silence to allow after
+    # the announcement finishes; 0 keeps the conversation open indefinitely, matching
+    # wake-word behaviour.
+    - service: announce_with_timeout
+      variables:
+        message: string
+        timeout: int
+      then:
+        - if:
+            condition:
+              switch.is_off: master_mute_switch
+            then:
+              - elevenlabs_stream.start:
+                  initial_message: !lambda 'return message;'
+                  timeout: !lambda 'return timeout;'
+            else:
+              - logger.log: "Announcement suppressed: the device is muted"
+
+    # Retained under its original name so existing automations keep working.
     - service: send_notification
       variables:
         message: string

--- a/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
+++ b/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
@@ -137,10 +137,10 @@ api:
     #     message: "Your laundry is finished."
     #     silence_seconds: 3
     #
-    # The silence is timed by ElevenLabs, not here: it is sent as a
-    # silence_end_call_timeout override when the conversation opens. The service is
-    # already running the turn model and the transcriber, so it can tell a pause from a
-    # reply; the device only sees a continuous microphone stream and would be guessing.
+    # The silence is timed on the device, off the vad_score events ElevenLabs already
+    # sends -- its own estimate of whether a person is speaking. Its
+    # silence_end_call_timeout cannot be used instead: it is not an overridable setting,
+    # and a conversation sent an override it does not accept is rejected outright.
     #
     # Answer and the conversation simply continues as a normal one. Say nothing and it
     # closes itself.
@@ -155,10 +155,9 @@ api:
             then:
               - elevenlabs_stream.start:
                   initial_message: !lambda 'return message;'
-                  # start_stream takes milliseconds; it converts to whole seconds for
-                  # the override. Fall back to 3s if the caller passes 0 or omits it,
-                  # so an announcement can never inherit the agent's 30s default and
-                  # sit with the microphone open.
+                  # start_stream takes milliseconds. Fall back to 3s if the caller
+                  # passes 0 or omits it, so an announcement can never inherit the
+                  # agent's 30s default and sit with the microphone open.
                   timeout: !lambda 'return silence_seconds > 0 ? silence_seconds * 1000 : 3000;'
             else:
               - logger.log: "Announcement suppressed: the device is muted"


### PR DESCRIPTION
Lets Home Assistant start an ElevenLabs conversation with an opening line. The device speaks, then stays in a normal conversation until the user has been silent long enough.

```yaml
service: esphome.<device>_announce
data:
  message: "Your laundry is finished."
  silence_seconds: 3
```

Answer and it continues as an ordinary conversation. Say nothing and it closes itself.

## Timing the silence took two wrong turns

**Attempt one — a local timer.** It measured the gap between outgoing microphone chunks, via `last_user_input_time_`. The microphone streams continuously from the moment the socket opens, so that gap was always ~0 and the timeout could never fire. The pre-existing `send_notification` service shipped with the same dead timeout.

**Attempt two — hand it to ElevenLabs.** Sent as a `turn.silence_end_call_timeout` override, on the reasoning that the service is already running the turn model and can tell a pause from a reply. This PR originally did that, with a note that I had not seen the service acknowledge the field. It doesn't, and it can't:

- `silence_end_call_timeout` is not overridable. The set is the system prompt, `first_message`, `language`, the LLM, `tool_ids`, the knowledge base, the TTS voice settings, `text_only` and `asr.keywords` — nothing about turn taking.
- An unaccepted override is not ignored. [The docs](https://elevenlabs.io/docs/eleven-agents/customization/personalization/overrides) are explicit that an error is thrown when a field arrives without overrides enabled for it, with `asr.keywords` the one soft exception.

So every announcement would have failed at conversation init.

## What it does now

A local timer again, but driven by a signal that means something: **`vad_score`** — [the service's own probability that a person is speaking](https://elevenlabs.io/docs/agents-platform/customization/events/client-events). The component has been receiving and decoding these all along to drive the LED ring; nothing new is subscribed to.

The window is held shut — not merely reset — while the agent has yet to speak, while its audio is playing, and until the speaker has fallen quiet. It starts at the first moment none of those hold, and any `vad_score` ≥ 0.5 pushes it back. A `user_transcript` closes it for good, since past that point somebody is in the conversation and it should live by the agent's own settings.

0.5 rather than the ring's 0.25 on purpose. The LED is meant to be twitchy — lighting up early feels responsive and costs nothing when wrong — but the same twitchiness here would let a fridge hum hold a call open indefinitely. A false negative only ends a conversation nobody was having.

Two things fall out of this:

- Speaker state is checked with `has_buffered_data()`, not `is_running()`. The speaker is started once per conversation and stopped only at the end, so `is_running()` is true throughout and the clock would never start.
- An announcement that produces no audio at all is now bounded (20s). Otherwise "the agent is still busy" stays true forever and the socket is left open on a conversation nobody in the room knows about.

## One service

`announce`, taking `message` and `silence_seconds`.

`silence_seconds` falls back to 3 when omitted or zero, so an announcement can never inherit the agent's configured 30s default and sit there with the microphone open. Wake-word conversations pass no window at all and are untouched by any of this.

It also checks `master_mute_switch` first — a muted device should not start talking on its own.

This replaces `send_notification`, whose timeout never worked. Any automation using it needs updating to `announce`.

Also removes three fields that were only ever written to: `conversation_timeout_ms_`, `last_user_input_time_`, and the setter feeding the first.

## Status

**Compiles clean. Not tested on hardware**, as requested.

Worth confirming on the first real run: that ElevenLabs delivers `first_message` for your agent, since the whole flow depends on the device speaking first. That override predates this branch and the device works today, so the toggle is already enabled — but it has never been exercised with a non-empty value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
