### PR TITLE
ci(elevenlabs): resolve the Cloudflare Access token for the tunnel checks

### DIFF
--- a/elevenlabs/op.env
+++ b/elevenlabs/op.env
@@ -6,3 +6,5 @@ HEY_JARVIS_GOOGLE_GENERATIVE_AI_API_KEY="op://Jarvis/Google/Hey Jarvis generativ
 HEY_JARVIS_OPENWEATHERMAP_API_KEY="op://Jarvis/Openweathermap/API key"
 HEY_JARVIS_CLOUDFLARED_TUNNEL_TOKEN="op://Jarvis/Jarvis/Cloudflared token"
 HEY_JARVIS_CLOUDFLARED_TUNNEL_URL="op://Jarvis/Jarvis/Cloudflared URL"
+HEY_JARVIS_CLOUDFLARE_ACCESS_CLIENT_ID="op://Jarvis/Jarvis/Cloudflare Access client ID"
+HEY_JARVIS_CLOUDFLARE_ACCESS_CLIENT_SECRET="op://Jarvis/Jarvis/Cloudflare Access client secret"


### PR DESCRIPTION
## ⚠️ Create the 1Password fields before merging

`run-with-env.sh` falls back to `op run` for anything missing from the environment, and `op run` fails outright on a reference it cannot resolve. An unresolvable entry here takes down **every** elevenlabs test run, not just the ones that need the token — so this stays a draft until the fields exist.

Two fields on the existing `Jarvis` item, in the `Jarvis` vault:

| Field name | Value |
| --- | --- |
| `Cloudflare Access client ID` | the service token's Client ID |
| `Cloudflare Access client secret` | the service token's Client Secret |

Same service token production already uses — nothing new to create in Cloudflare or ElevenLabs.

If you'd rather name them differently, change the two lines here to match; the variable names on the left are what the code reads and should stay as they are.

## What this adds

```diff
 HEY_JARVIS_CLOUDFLARED_TUNNEL_TOKEN="op://Jarvis/Jarvis/Cloudflared token"
 HEY_JARVIS_CLOUDFLARED_TUNNEL_URL="op://Jarvis/Jarvis/Cloudflared URL"
+HEY_JARVIS_CLOUDFLARE_ACCESS_CLIENT_ID="op://Jarvis/Jarvis/Cloudflare Access client ID"
+HEY_JARVIS_CLOUDFLARE_ACCESS_CLIENT_SECRET="op://Jarvis/Jarvis/Cloudflare Access client secret"
```

Placed on the same 1Password item as the Cloudflared token and URL, so the tunnel's credentials stay together.

## Why

#627 taught the checks that cross the tunnel to send `CF-Access-Client-Id` and `CF-Access-Client-Secret` — the health check, the MCP endpoint probe, and the MCP client — but only when those variables are set, so nothing changed. This tells `run-with-env.sh` where to find them, which is what makes the Access application in front of `jarvis-local-testing.ffmathy.org` survivable for CI.

Without it, the first run after Access goes live fails at the tunnel health check with a 403, before the agent gets a chance to do anything.

## Order of operations

1. Create the two 1Password fields
2. Merge this
3. Create the Access application (Self-hosted, **Service Auth** policy, include the production service token)
4. In ElevenLabs, swap MCP server `GMOqF385QS1GsrZKfQk6` from its secret token to the two `CF-Access-*` request headers

Steps 1–2 before 3 means CI is already sending the token when Access starts requiring it.

## Validation

`bunx turbo lint` (lint + typecheck, 6/6) passes. The reference paths themselves cannot be verified from here — this environment has no 1Password authentication — which is exactly why this is a draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xdv9RdSFhbu96f75mhhU2e)_