### PR TITLE
test(elevenlabs): say when Access refused the request

### DIFF
--- a/elevenlabs/tests/utils/tunnel-manager.ts
+++ b/elevenlabs/tests/utils/tunnel-manager.ts
@@ -167,11 +167,22 @@ export async function ensureTunnelRunning(): Promise<void> {
 
   console.log(`🌐 Token length: ${token.length} characters`);
 
+  // cloudflared logs the tunnel-related variables it finds in its environment,
+  // verbatim, at startup — and CI logs are public. It masks the token when it
+  // arrives as a flag, so pass it that way and keep it out of the environment
+  // the child inherits.
+  const {
+    HEY_JARVIS_CLOUDFLARED_TUNNEL_TOKEN: _token,
+    HEY_JARVIS_CLOUDFLARED_TUNNEL_URL: _url,
+    ...environmentWithoutTunnelSecrets
+  } = process.env;
+
   // Start cloudflared tunnel in background with HTTP2 protocol (more reliable than QUIC)
   // Using --protocol http2 to avoid UDP/QUIC blocking issues in some network environments
   tunnelProcess = spawn('cloudflared', ['tunnel', '--protocol', 'http2', 'run', '--token', token], {
     detached: false,
     stdio: ['ignore', 'inherit', 'inherit'],
+    env: environmentWithoutTunnelSecrets,
   });
 
   tunnelProcess.on('error', (error) => {

--- a/elevenlabs/tests/utils/tunnel-manager.ts
+++ b/elevenlabs/tests/utils/tunnel-manager.ts
@@ -49,7 +49,12 @@ async function isTunnelRunning(): Promise<boolean> {
  * Cloudflare answers with its own error pages while the tunnel is down, so the
  * body has to confirm our MCP server is the one on the other end.
  */
-async function checkTunnelHealth(): Promise<{ ok: boolean; status?: number; error?: string }> {
+async function checkTunnelHealth(): Promise<{
+  ok: boolean;
+  status?: number;
+  error?: string;
+  rejectedByAccess?: boolean;
+}> {
   const healthUrl = `${process.env.HEY_JARVIS_CLOUDFLARED_TUNNEL_URL}/health`;
   try {
     const response = await fetch(healthUrl, {
@@ -59,6 +64,23 @@ async function checkTunnelHealth(): Promise<{ ok: boolean; status?: number; erro
     });
     if (!response.ok) {
       return { ok: false as const, status: response.status, error: `HTTP ${response.status}` };
+    }
+
+    // Cloudflare Access answers a request it will not let through with its own
+    // page, and a login page is still a 200. Saying so beats letting the JSON
+    // parse fail and reporting that instead.
+    const contentType = response.headers.get('content-type') ?? 'none';
+    if (!contentType.includes('application/json')) {
+      const sentServiceToken = Object.keys(cloudflareAccessHeaders()).length > 0;
+      return {
+        ok: false as const,
+        status: response.status,
+        error:
+          `expected JSON from /health but got ${contentType}, which is what Cloudflare Access serves ` +
+          `when it does not accept the request (service token sent: ${sentServiceToken}). ` +
+          `Check that the Access policy's action is Service Auth and that it includes this token.`,
+        rejectedByAccess: true,
+      };
     }
 
     const data = (await response.json()) as { status?: string };
@@ -172,6 +194,12 @@ export async function ensureTunnelRunning(): Promise<void> {
         return;
       }
 
+      // Access decides on the credentials presented, and those do not improve by
+      // being offered again — so stop rather than spend a minute proving it.
+      if (healthResult.rejectedByAccess) {
+        throw new Error(`Tunnel reachable but Access refused the request: ${healthResult.error}`);
+      }
+
       // If health check fails, try the MCP endpoint (requires JWT)
       const isRunning = await isTunnelRunning();
       if (isRunning) {
@@ -184,6 +212,7 @@ export async function ensureTunnelRunning(): Promise<void> {
       maxRetries: 60,
       initialDelay: 1000,
       backoffMultiplier: 1, // Linear retry (1 second between attempts)
+      shouldRetry: (error) => !error.message.startsWith('Tunnel reachable but Access refused'),
       onRetry: (error, attempt, _delay) => {
         // Log extra diagnostics every 10 attempts
         if (attempt % 10 === 0) {


### PR DESCRIPTION
## What happened

The first run after #659 got as far as the tunnel and then said this, sixty times:

```
🌐 Starting cloudflared tunnel...
error: Operation failed after 60 attempts: Tunnel not ready: Failed to parse JSON
  at agent-prompt.spec.ts:110
```

Cloudflare Access is now in front of the test hostname — that part works. What it serves to a request it will not let through is its own page, and that page is still an HTTP 200, so `response.ok` passed and the only thing that objected was `response.json()`. The MCP client hit the same wall from the other side: `Invalid content type, expected "text/event-stream"`.

Two things came out of it that are worth keeping: the 1Password references from #659 resolve (`op run` succeeded, so the fields exist under the names used), and the local MCP server still starts fine. The tunnel is the only thing failing, and it is failing on authorization rather than reachability.

## Changes

A non-JSON `/health` response is now reported as what it is:

```
expected JSON from /health but got text/html, which is what Cloudflare Access serves
when it does not accept the request (service token sent: true). Check that the Access
policy's action is Service Auth and that it includes this token.
```

`service token sent` distinguishes the two cases that matter — the token never reaching the request, versus reaching it and being refused.

The retry loop also stops on this now, via `shouldRetry`. Credentials do not become acceptable on the second attempt, and a minute of retries buries the reason under sixty identical lines.

## What this does not fix

Whatever Access is unhappy about. This makes the next run say which of these it is:

- **`service token sent: false`** — the values are not reaching the request. The variable names the code reads are `HEY_JARVIS_CLOUDFLARE_ACCESS_CLIENT_ID` and `HEY_JARVIS_CLOUDFLARE_ACCESS_CLIENT_SECRET`; if the 1Password fields hold something else, or are empty, that is where to look.
- **`service token sent: true`** — the token is being presented and refused. Most likely the Access policy's action is Allow rather than **Service Auth** (Allow redirects to an identity provider, which no headless client can complete), or the policy does not include this particular token.

Draft until the next run reports one or the other.

## Validation

`bunx turbo lint` (lint + typecheck, 6/6) passes. The Access behaviour itself cannot be exercised from this sandbox — the hostname is proxy-blocked here, which is why this is diagnostics rather than a fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xdv9RdSFhbu96f75mhhU2e)_