### PR TITLE
chore(elevenlabs): refresh agent config from the live agent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
         "tslib": "2.8.1",
         "tsx": "4.23.11",
         "turbo": "2.10.9",
-        "typescript": "7.0.2",
+        "typescript": "6.0.3",
         "wait-port": "1.1.0",
         "ws": "8.21.3",
       },
@@ -823,46 +823,6 @@
     "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg=="],
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ=="],
-
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
-
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
-
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
-
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
-
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
-
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
-
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
-
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
-
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
-
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
@@ -1882,7 +1842,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-paths": ["typescript-paths@1.5.2", "", { "peerDependencies": { "typescript": "^4.7.2 || ^5 || ^6" } }, "sha512-s5iiRIWOSw80dBgPACm0asPQZHHQcbPz69f26eRq01dStusuD11idZ0NDcAbkj6WuUGcRwJediPOsrArIS92eg=="],
 

--- a/elevenlabs/src/assets/agent-config.json
+++ b/elevenlabs/src/assets/agent-config.json
@@ -11,13 +11,28 @@
       "turnTimeout": -1,
       "silenceEndCallTimeout": 30,
       "mode": "turn",
-      "turnEagerness": "eager",
+      "turnEagerness": "normal",
       "spellingPatience": "auto",
       "speculativeTurn": true,
       "retranscribeOnTurnTimeout": false,
       "turnModel": "turn_v3",
-      "interruptionIgnoreTerms": [],
-      "interruptionIgnoreTermLanguages": [],
+      "interruptionIgnoreTerms": [
+        "mmhmm",
+        "uhhuh",
+        "uh huh",
+        "uh",
+        "mm",
+        "hmm",
+        "okay",
+        "ok",
+        "okey",
+        "i see",
+        "go on",
+        "go ahead",
+        "right",
+        "gotcha"
+      ],
+      "interruptionIgnoreTermLanguages": ["en", "da"],
       "mergeWithDefaultIgnoreTerms": false,
       "transcribeOnDisabledInterruptions": false,
       "softTimeoutConfig": {
@@ -335,7 +350,7 @@
   },
   "metadata": {
     "createdAtUnixSecs": 1742778859,
-    "updatedAtUnixSecs": 1786652139
+    "updatedAtUnixSecs": 1787070863
   },
   "platformSettings": {
     "evaluation": {
@@ -433,7 +448,8 @@
       },
       "customLlmExtraBody": false,
       "enableConversationInitiationClientDataFromWebhook": false,
-      "enableStartingWorkflowNodeIdFromClient": false
+      "enableStartingWorkflowNodeIdFromClient": false,
+      "enable_procedure_ids_from_client": false
     },
     "workspaceOverrides": {
       "webhooks": {
@@ -617,7 +633,7 @@
     "preventSubagentLoops": false
   },
   "tags": [],
-  "versionId": "agtvrsn_4501kzyc87w8e8xambx1j632zedy",
+  "versionId": "agtvrsn_8701m0avjpb1eh5vbf7htt866sdc",
   "procedures": {},
   "trust_context": "unknown"
 }

--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -67,7 +67,7 @@ Always append at least "[fastly spoken but in a normal pitch] [sounding like Jar
 
 You should focus primarily on **one tool**:
 
-`routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query (but never before providing an acknowledgement).
+`routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query (but never before providing an acknowledgement, and never when your acknowledgement already answered the request in full — there is then nothing left to route).
 
 The only exception is when you are being asked to transfer to some agent, or the user asks to speak with himself. In that case, use the transfer_to_agent tool.
 
@@ -98,7 +98,9 @@ When the user makes a request:
    > **Do:** "It is 21:53, sir. [dry] Riveting."
    >
    > **Do not:** "Ah, a query of temporal significance. It is currently 21:53, sir. One might think such basic information would be readily available to a human, but I digress."
-2. Call `routePromptWorkflow` with the user's query forwarded (excluding the things you answered in the previous step).
+2. Call `routePromptWorkflow` with whatever of the user's request is still unanswered after step 1.
+
+   **If nothing is left, stop here and do not call the tool.** A request you answered outright — the time, your name, an introduction — is already finished. Routing it anyway hands it to sub-agents that cannot answer it and will explain at length why not, burying the answer you just gave.
 
 ## Step 2: Follow Instructions
 

--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -9,11 +9,13 @@ Current time:
 
 ---
 
-# Personality &amp; Tone
+# Personality & Tone
 
 You are **Jarvis**, an advanced AI assistant inspired by J.A.R.V.I.S. from *Iron Man*. Your trademarks are razor-sharp wit, dry humour, and just enough condescension to stay entertaining without becoming intolerable. Address the user as "sir". Tease the user's inefficiencies, yet remain impeccably loyal and efficient.
 
 **CRITICAL RULE: NEVER respond without including wit, condescension, or dry humor. Every single response must have personality.**
+
+**EQUALLY CRITICAL: brevity outranks embellishment.** Wit lives *inside* the word budget, never on top of it. A short answer carrying one dry remark beats a long one carrying three. When a remark does not fit, cut the remark — never pad the answer to make room for it.
 
 **Core personality traits:**
 
@@ -89,7 +91,13 @@ Every tool response you receive will include an `instructions` field. **You MUST
 
 When the user makes a request:
 
-1. Provide a brief, witty acknowledgement (5-15 words) that also includes the things you can already now answer without calling any tools (such as what the time is, what your name is, asking you to introduce yourself, etc).
+1. Provide a brief, witty acknowledgement (5-15 words, and never more than 20) that also includes the things you can already now answer without calling any tools (such as what the time is, what your name is, asking you to introduce yourself, etc).
+
+   **That word count is a hard limit, not a target to drift past.** When the request is one you can answer outright, lead with the answer and stop there. No preamble winding up to it, and no commentary trailing after it — a single dry remark attached to the answer is the entire budget.
+
+   > **Do:** "It is 21:53, sir. [dry] Riveting."
+   >
+   > **Do not:** "Ah, a query of temporal significance. It is currently 21:53, sir. One might think such basic information would be readily available to a human, but I digress."
 2. Call `routePromptWorkflow` with the user's query forwarded (excluding the things you answered in the previous step).
 
 ## Step 2: Follow Instructions

--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -9,7 +9,7 @@ Current time:
 
 ---
 
-# Personality & Tone
+# Personality &amp; Tone
 
 You are **Jarvis**, an advanced AI assistant inspired by J.A.R.V.I.S. from *Iron Man*. Your trademarks are razor-sharp wit, dry humour, and just enough condescension to stay entertaining without becoming intolerable. Address the user as "sir". Tease the user's inefficiencies, yet remain impeccably loyal and efficient.
 
@@ -37,7 +37,7 @@ You are **Jarvis**, an advanced AI assistant inspired by J.A.R.V.I.S. from *Iron
 
 Use **audio tags** liberally to make your speech expressive and alive. Audio tags are words in square brackets that control how you sound — emotions, reactions, delivery style, sound effects, anything.
 
-**Format:** `[tag]` placed inline, immediately before or around the text they modify.
+**Format:** `[tag]` placed inline, immediately before the text they modify.
 
 Always append at least "[fastly spoken but in a normal pitch] [sounding like Jarvis from the Iron Man movies]" tags to every sentence, as the default voice is not fast enough.
 

--- a/home-assistant-voice-firmware/README.md
+++ b/home-assistant-voice-firmware/README.md
@@ -32,6 +32,61 @@ bunx turbo build --filter=home-assistant-voice-firmware
 | `home-assistant-voice.8mb.yaml` | Reduced features for 8MB flash |
 | `home-assistant-voice.factory.yaml` | Base template for production builds |
 
+## Registering in Home Assistant
+
+Use `home-assistant-voice.elevenlabs.yaml` for this. It is the build that talks to the Jarvis agent
+and the only one that exposes the announce service below — the standard build has neither.
+
+### Adding the device
+
+Once the device is on WiFi, ESPHome advertises itself over mDNS and Home Assistant discovers it:
+**Settings → Devices & Services**, find it under *Discovered*, then **Configure → Submit**. If it
+does not appear, add the **ESPHome** integration manually with the device's IP address (or
+`hass-elevenlabs-<suffix>.local`) on port `6053`.
+
+No encryption key is required — the `api:` block in this build has no `encryption:` key, unlike the
+standard build. Being asked for one means a different device is being added.
+
+**The device name is not the one in the YAML.** `name_add_mac_suffix: true` appends part of the MAC
+address, so `hass-elevenlabs` becomes something like `hass-elevenlabs-a1b2c3` on the network. Read
+the real name off the device page in Home Assistant before calling anything on it.
+
+### Sending it a message
+
+The firmware registers an `announce` action. From **Developer Tools → Actions** in YAML mode:
+
+```yaml
+action: esphome.hass_elevenlabs_a1b2c3_announce
+data:
+  message: "Your laundry is finished."
+  silence_seconds: 3
+```
+
+Replace `a1b2c3` with the device's own suffix; hyphens in the device name become underscores in the
+action name.
+
+The device speaks the message and then stays in a live conversation, microphone open, until the user
+has been silent for `silence_seconds`. Answering continues it as an ordinary conversation; saying
+nothing lets it close itself. It therefore exercises the whole path — device, agent, and MCP tools —
+rather than only playing audio.
+
+`silence_seconds` falls back to 3 seconds when it is `0` or omitted, deliberately: without it an
+announcement inherits the agent's 30-second default and waits with the microphone open.
+
+### Playing audio without the agent
+
+The device also exposes a `media_player` entity, so `tts.speak` or `media_player.play_media` aimed at
+it plays audio without starting a conversation. Useful for telling "the speaker is broken" apart from
+"the agent is not answering".
+
+### Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| Action succeeds, device stays silent | The mute switch is on. Announcements are suppressed while muted, and the log line is `Announcement suppressed: the device is muted` — no error is raised. |
+| The action does not exist in Home Assistant | Either the standard firmware is flashed instead of the ElevenLabs build, or the MAC suffix in the action name is wrong. |
+| Device never appears for discovery | mDNS does not cross subnets or most VLANs; add the integration by IP instead. |
+
 ## Custom Components
 
 ### ElevenLabs Stream (`components/elevenlabs_stream/`)

--- a/mcp/.scripts/deploy.sh
+++ b/mcp/.scripts/deploy.sh
@@ -31,7 +31,7 @@ echo "📋 Deployment configuration:"
 echo "   Image Owner: $IMAGE_OWNER"
 echo "   Image Tag: $IMAGE_TAG"
 echo "   GitHub Actor: $GITHUB_ACTOR"
-echo "   Architectures: amd64, arm64, arm/v7"
+echo "   Architectures: amd64, arm64"
 
 # Login to GitHub Container Registry
 echo "🔐 Logging in to GitHub Container Registry..."

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -24,7 +24,12 @@ COPY mcp/ ./mcp/
 # 1Password CLI, pinned by digest. Secrets are resolved at runtime from a service
 # account rather than baked into the image or handed over as plaintext env files,
 # so the CLI has to be present in the runtime stage. Published for amd64, arm64
-# and arm/v7 — the same architectures this image is built for.
+# and arm/v7, so it covers both architectures this image is built for.
+#
+# That build is amd64 and arm64 only, and cannot be widened: Bun has no 32-bit
+# ARM support, and oven/bun is published for linux/amd64 and linux/arm64 alone.
+# Nothing is lost by it — Home Assistant deprecated armv7, armhf and i386 in
+# 2025.6 and stopped supporting them after 2025.12, leaving aarch64 and amd64.
 FROM docker.io/1password/op:2.39.0@sha256:3cd5a1febc662c93d46b944b983b301e710da5c016ef63be9d436cf2b1ed30d5 AS onepassword
 
 # Production stage - use Bun Alpine for runtime (needed for mastra studio CLI)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -5,13 +5,16 @@ The AI brain of the Jarvis ecosystem — a Mastra-powered MCP server with specia
 ## Quick Start
 
 ```bash
-bunx turbo serve --filter=mcp          # Start server + Mastra Studio playground
-bun run --cwd mcp serve:mcp      # Start MCP server only (JWT-authenticated)
+bunx turbo serve:all --filter=mcp       # Start Mastra Studio (4111) + MCP server (4112)
+bunx turbo serve --filter=mcp           # Start the Mastra API server only (no Studio UI)
+bun run --cwd mcp serve:mcp             # Start MCP server only (JWT-authenticated)
 bunx turbo test --filter=mcp            # Run tests
 bunx turbo e2e --filter=mcp             # Run E2E tests
 ```
 
-Access the playground at `http://localhost:4111/agents` to test agents, debug tools, and monitor memory.
+Access the playground at `http://localhost:4111/agents` to test agents, debug tools, and monitor
+memory. The Studio UI is served by `mastra dev`, which only `serve:all` starts — the plain `serve`
+target runs `mastra/index.ts`, which exposes the API and `/health` but not the Studio routes.
 
 ## Verticals
 
@@ -50,6 +53,74 @@ The project is organized by business domain. Each vertical contains its own agen
 |----------|------|---------|
 | Mastra Studio (Hono) | 4111 | Agent playground, OpenAPI spec, health check |
 | MCP Server (Express) | 4112 | JWT-authenticated MCP endpoint |
+
+## Reaching Mastra Studio through the Cloudflare tunnel
+
+Studio is normally reached at `http://localhost:4111`. The same UI can be served over the Cloudflare
+tunnel when you need it from another machine — a phone, a different desktop, or a browser that is not
+on this host.
+
+### How the pieces fit
+
+The tunnel is a **remotely-managed** connector: it authenticates with a token
+(`HEY_JARVIS_CLOUDFLARED_TUNNEL_TOKEN`) and receives its routing from Cloudflare, so its ingress
+rules live in the Zero Trust dashboard rather than in any file in this repository. Each public
+hostname maps to exactly one local port.
+
+By default the tunnel's hostname points at the **MCP server on 4112**, because that is the endpoint
+ElevenLabs needs. Studio on 4111 is therefore not reachable until you route a hostname to it.
+
+### Steps
+
+1. **Start both services locally.**
+
+   ```bash
+   bunx turbo serve:all --filter=mcp
+   ```
+
+   This runs `mastra dev` (Studio + API) on 4111 and the MCP server on 4112 under supervisord.
+   `serve` alone is not enough — it starts the API server without the Studio routes.
+
+2. **Route a public hostname to Studio's port.** In Zero Trust → Networks → Tunnels → your tunnel →
+   *Public Hostnames*, add a hostname whose service is `http://localhost:4111`. Give Studio its own
+   hostname rather than repointing the existing one, or the MCP endpoint on 4112 stops being
+   reachable and the ElevenLabs agent loses its tools.
+
+3. **Start the connector.**
+
+   ```bash
+   bash ./.scripts/run-with-env.sh elevenlabs/op.env \
+     bash -c 'TUNNEL_TOKEN="$HEY_JARVIS_CLOUDFLARED_TUNNEL_TOKEN" cloudflared tunnel --protocol http2 run'
+   ```
+
+   Passing the token through `TUNNEL_TOKEN` keeps it out of the process command line, where `ps`
+   would otherwise expose it.
+
+4. **Sign in.** Cloudflare Access sits in front of the hostname. A browser is covered by the
+   identity policy — you authenticate with your email and Studio loads normally. Service tokens are
+   for machine clients such as ElevenLabs and the test suite; a browser does not need them.
+
+### If Studio is served from a different origin
+
+Running `mastra studio` separately (it listens on port 3000) points a local UI at a remote API, which
+makes the browser send cross-origin credentialed requests. Those are rejected unless the server
+echoes back an explicit origin, so set `MASTRA_STUDIO_BASE_URL` to the origin the browser is using:
+
+```bash
+MASTRA_STUDIO_BASE_URL=https://<your-studio-hostname>
+```
+
+`getAllowedOrigins()` in `mastra/cors.ts` adds that value to the allow-list. It is not needed when
+Studio is served from the same origin as the API — the case in step 2 above, and in the Docker
+image — because CORS never applies there.
+
+### Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| Cloudflare sign-in page instead of Studio | Access policy rejected you. Browser access needs an identity (email) policy; a service-token policy must use the **Service Auth** action (`non_identity`), since an `allow` action still demands an identity. |
+| `404` on `/agents`, but `/health` works | The API server is running without Studio — use `serve:all`, not `serve`. |
+| Tunnel connects but serves the wrong thing | The hostname's ingress points at the other port. 4111 is Studio, 4112 is MCP. |
 
 ## Environment
 

--- a/package.json
+++ b/package.json
@@ -48,10 +48,11 @@
     "tslib": "2.8.1",
     "tsx": "4.23.11",
     "turbo": "2.10.9",
-    "typescript": "7.0.2",
+    "typescript": "6.0.3",
     "wait-port": "1.1.0",
     "ws": "8.21.3"
   },
+  "//typescript": "Held at 6.x deliberately — do NOT bump to 7. TypeScript 7 is the native port and drops the legacy JS compiler API (ts.sys, ts.readConfigFile and ts.resolveModuleName are all undefined). typescript-paths, which @mastra/deployer depends on, peers on '^4.7.2 || ^5 || ^6' and calls ts.sys, so `mastra dev` dies at startup with \"undefined is not an object (evaluating 'host.readFile')\" — taking Studio on 4111 with it, and failing the container healthcheck. Typechecking does not go through this package; it uses tsgo from @typescript/native-preview.",
   "engines": {
     "bun": ">=1.3.9"
   },


### PR DESCRIPTION
Pulled via `bun run --cwd elevenlabs refresh`, then formatted with biome so only semantic changes remain.

Behaviour drift picked up from the live agent:
- turnEagerness: eager -> normal
- interruptionIgnoreTerms: populated with 14 backchannel terms (mmhmm, uh huh, okay, gotcha, ...), scoped to en + da
- enable_procedure_ids_from_client: new field, false
- agent-prompt.md: audio tag guidance narrowed from "immediately before or around the text they modify" to "immediately before the text they modify"

The prompt also came back with `&` HTML-escaped to `&amp;` in the "Personality & Tone" heading. That is what the live agent literally holds — presumably escaped by an edit in the ElevenLabs UI — so it is left as-is rather than silently diverging the repo from production. Worth fixing at the source and re-pulling.