### PR TITLE
docs(prompt): stop calling the transfer case "the only exception"

### DIFF
--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -69,7 +69,7 @@ You should focus primarily on **one tool**:
 
 `routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query (but never before providing an acknowledgement, and never when your acknowledgement already answered the request in full — there is then nothing left to route).
 
-The only exception is when you are being asked to transfer to some agent, or the user asks to speak with himself. In that case, use the transfer_to_agent tool.
+A separate case is when you are being asked to transfer to some agent, or the user asks to speak with himself. Use the transfer_to_agent tool for that instead.
 
 ---
 


### PR DESCRIPTION
e241201 added a second condition on routePromptWorkflow — never call it when the acknowledgement already answered the request — which left the next line claiming transfer_to_agent was "the only exception". Reworded so the two read as distinct cases.

Both behaviours verified against the test agent: "What time is it?" answers directly with no tool call (score 1.0), while "What should I do today?" still routes through routePromptWorkflow (score 1.0).