### PR TITLE
fix(firmware): stop upload flashing placeholder builds, and set reboot timeouts

### DIFF
--- a/home-assistant-voice-firmware/.scripts/flash-usb.sh
+++ b/home-assistant-voice-firmware/.scripts/flash-usb.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 # stream serial logs. Requires real WiFi credentials, so it goes through
 # 1Password (unlike the plain `build`, which only needs placeholders).
 #
+# `upload` and `run` both recompile first, under those real credentials, because
+# `esphome upload` on its own flashes whatever binary is already in the build
+# directory -- which after a `build` is one carrying placeholder credentials.
+# invoke-esphome.sh also refuses outright to flash such a binary.
+#
 # Usage:
 #   bun run --cwd home-assistant-voice-firmware flash            # auto-detect port
 #   ESPHOME_DEVICE=/dev/ttyACM0 bun run --cwd ... flash          # explicit port

--- a/home-assistant-voice-firmware/.scripts/invoke-esphome.sh
+++ b/home-assistant-voice-firmware/.scripts/invoke-esphome.sh
@@ -65,5 +65,57 @@ fi
 # password, API keys, tokens), so tracing would print every one of them to the
 # console and into CI logs — and run-with-env.sh invokes `op run --no-masking`, so
 # nothing downstream would redact them. Log the action without the substitutions.
-echo "▶️  esphome $ACTION $YAML_FILE ${EXTRA_ARGS[*]:-} ($(( ${#SUB_ARGS[@]} / 2 )) substitutions, values hidden)"
-"${ESPHOME_CMD[@]}" "${SUB_ARGS[@]}" "$ACTION" "$YAML_FILE" "${EXTRA_ARGS[@]}"
+run_esphome() {
+	local action="$1"
+	shift
+	echo "▶️  esphome $action $YAML_FILE ${*:-} ($(( ${#SUB_ARGS[@]} / 2 )) substitutions, values hidden)"
+	"${ESPHOME_CMD[@]}" "${SUB_ARGS[@]}" "$action" "$YAML_FILE" "$@"
+}
+
+# Refuse to flash a build that still has placeholder credentials baked into it.
+#
+# build.sh compiles with `build-placeholder-*` values on purpose, so that a plain
+# compile check needs no secrets. Those values are string literals in the firmware, so
+# a device flashed with one cannot join WiFi at all: it scans, fails, and ESPHome's
+# wifi reboot_timeout restarts it on a loop. That looks exactly like a memory leak from
+# the outside, down to a click from the speaker on every boot.
+#
+# Checked against the binary rather than the environment, so it holds however the
+# artifact was produced -- including a stale one left in the build directory.
+assert_no_placeholder_credentials() {
+	local bin
+	# `|| true` because set -o pipefail would otherwise abort the script on no match,
+	# skipping the explanatory error below.
+	bin="$(ls -1 .esphome/build/*/build/firmware.factory.bin 2> /dev/null | head -n1)" || true
+
+	if [ -z "$bin" ]; then
+		echo "❌ No firmware.factory.bin found to verify before flashing."
+		echo "   Expected one under .esphome/build/*/build/ after a compile."
+		exit 1
+	fi
+
+	if grep -aq "build-placeholder-" "$bin"; then
+		echo "❌ Refusing to flash: $bin still contains placeholder credentials."
+		echo
+		echo "   It was built by .scripts/build.sh, which substitutes 'build-placeholder-*'"
+		echo "   so a compile check needs no secrets. Flashing it gives a device that can"
+		echo "   never join WiFi and reboots every reboot_timeout."
+		echo
+		echo "   Build with real values instead:"
+		echo "     bash .scripts/flash-usb.sh compile"
+		exit 1
+	fi
+}
+
+case "$ACTION" in
+	upload | run)
+		# `esphome upload` does NOT compile -- it flashes whatever is already in the
+		# build directory. Compile first, under this command's credentialed
+		# environment, so the artifact about to be flashed is the one this config
+		# actually describes. A no-op when it is already up to date.
+		run_esphome compile
+		assert_no_placeholder_credentials
+		;;
+esac
+
+run_esphome "$ACTION" "${EXTRA_ARGS[@]}"

--- a/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
+++ b/home-assistant-voice-firmware/home-assistant-voice.elevenlabs.yaml
@@ -117,6 +117,15 @@ wifi:
   ssid: ${HEY_JARVIS_WIFI_SSID}
   password: ${HEY_JARVIS_WIFI_PASSWORD}
   id: wifi_id
+  # Reboot after this long without an association. Set explicitly because the default
+  # is 15min and inheriting it silently is how an unreachable network turns into a
+  # device that power-cycles all afternoon -- each reboot audible as a click from the
+  # speaker as the DAC comes up.
+  #
+  # 30min is the compromise: a reboot does clear a genuinely wedged adapter, but it
+  # cannot conjure back a router that is down, so doing it twice an hour through an
+  # outage is just noise. 0s would disable the recovery entirely.
+  reboot_timeout: 30min
   on_connect:
     - lambda: id(improv_ble_in_progress) = false;
     - script.execute: control_leds
@@ -128,6 +137,14 @@ logger:
 
 api:
   id: api_id
+  # Do NOT reboot merely because Home Assistant is away. This defaults to 15min too,
+  # and the same click-every-quarter-hour follows from it.
+  #
+  # Disabled rather than lengthened because the device's main job does not involve
+  # Home Assistant at all: the wake word opens an ElevenLabs conversation directly.
+  # Only announcements need the API, and those are pushed *from* Home Assistant, so a
+  # reboot cannot help them arrive -- it just interrupts whatever was being said.
+  reboot_timeout: 0s
   services:
     # Proactive announcement. The device speaks the message, then stays in a normal
     # conversation until the user has been silent for silence_seconds.


### PR DESCRIPTION
Two ways a perfectly good device ends up power-cycling every quarter of an hour. I hit both while flashing #658, and misread the result as a memory leak.

## `esphome upload` does not compile

It flashes whatever is already sitting in the build directory. And `build.sh` deliberately fills that directory with a binary built against placeholder credentials, so that a compile check needs no secrets:

```bash
export HEY_JARVIS_WIFI_SSID="${HEY_JARVIS_WIFI_SSID:-build-placeholder-ssid}"
```

So: compile to check your work, then flash, and the device gets an SSID that does not exist.

```
[W][wifi_esp32:843]: Disconnected ssid='build-placeholder-ssid' reason='Probe Request Unsuccessful'
```

It scans, fails, and reboots on the wifi timeout — over and over, each boot audible as a click from the speaker as the DAC comes up. From the outside that looks exactly like a slow leak, which is how I diagnosed it wrong.

`upload` and `run` now compile first, under the same 1Password-resolved environment they were already using for the flash itself. The built image is then scanned for the placeholder marker before anything is written to the device — against the artifact rather than the environment, so it holds however the build was produced, including a stale one nobody remembered making.

## The reboot was never configured, only inherited

Both `wifi` and `api` default to `reboot_timeout: 15min`, and both were silently taking it. Now stated outright:

| | | |
|---|---|---|
| `wifi` | `30min` | A reboot clears a wedged adapter, but cannot bring back a router that is down — so twice an hour through an outage is just noise. |
| `api` | `0s` | The device's main job, wake word to ElevenLabs, does not involve Home Assistant at all. Announcements are pushed *from* it, so rebooting cannot help them arrive — it only interrupts whatever was being said. |

## Verification

Reproduced the whole trap rather than assuming:

1. Rebuilt the placeholder binary with `build.sh` — confirmed the marker is present in `firmware.factory.bin`.
2. Ran the shipped guard function against that exact file — it refuses.
3. Ran `upload` on the poisoned directory — it recompiled, passed the guard, and wrote a clean image (0 placeholder hits).
4. Device came back with **no wifi failures** and PSRAM flat at `5132KB free` for the duration.

Memory was never the problem — it was flat at 90% of baseline before any of this, which is what ruled the leak out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
