### PR TITLE
feat(synapse): score state changes by facet, and store a third-person rewrite

### DIFF
--- a/mcp/mastra/storage/subscriptions.ts
+++ b/mcp/mastra/storage/subscriptions.ts
@@ -48,6 +48,16 @@ export interface Subscription extends SubscriptionComponents {
 export interface EmbeddedSubscription extends Subscription {
   whenEmbedding: Float32Array;
   givenEmbedding: Float32Array | null;
+  /**
+   * Embedding of a third-person rewrite of `whenEvent`, when it was phrased in the
+   * first person. Matching takes the better of this and {@link whenEmbedding}, so a
+   * subscription is reachable both from how the user said it and from how a device
+   * reports it. Null when the clause contained no first-person pronouns, and on rows
+   * written before the column existed.
+   */
+  whenAltEmbedding: Float32Array | null;
+  /** The same, for `givenCondition`. */
+  givenAltEmbedding: Float32Array | null;
 }
 
 /** The embeddings supplied when creating a subscription. */
@@ -55,6 +65,10 @@ export interface SubscriptionEmbeddings {
   whenEvent: Float32Array;
   givenCondition: Float32Array | null;
   thenAction: Float32Array;
+  /** Third-person rewrite of `whenEvent`, when there was one to make. */
+  whenEventAlternate?: Float32Array | null;
+  /** Third-person rewrite of `givenCondition`, when there was one to make. */
+  givenConditionAlternate?: Float32Array | null;
 }
 
 /**
@@ -115,11 +129,36 @@ export class SubscriptionStorage {
         enabled INTEGER NOT NULL DEFAULT 1,
         created_at TEXT NOT NULL,
         last_triggered_at TEXT,
-        trigger_count INTEGER NOT NULL DEFAULT 0
+        trigger_count INTEGER NOT NULL DEFAULT 0,
+        when_alt_embedding BLOB,
+        given_alt_embedding BLOB
       )
     `);
 
+    // Databases created before the alternate phrasings existed are missing those two
+    // columns. Adding them is cheap and leaves existing rows with NULL, which matching
+    // already treats as "no alternate phrasing" — so an old subscription keeps working
+    // exactly as before and picks up the improvement whenever it is next re-registered.
+    await this.addMissingColumns();
+
     this.initialized = true;
+  }
+
+  /**
+   * Adds any columns a database predating them is missing.
+   *
+   * SQLite has no `ADD COLUMN IF NOT EXISTS`, so the current columns are read back from
+   * `PRAGMA table_info` and only the absent ones are added.
+   */
+  private async addMissingColumns(): Promise<void> {
+    const existing = await this.client.execute('PRAGMA table_info(synapse_subscriptions)');
+    const columnNames = new Set(existing.rows.map((row) => String(row.name)));
+
+    for (const column of ['when_alt_embedding', 'given_alt_embedding']) {
+      if (!columnNames.has(column)) {
+        await this.client.execute(`ALTER TABLE synapse_subscriptions ADD COLUMN ${column} BLOB`);
+      }
+    }
   }
 
   /**
@@ -156,8 +195,9 @@ export class SubscriptionStorage {
         INSERT INTO synapse_subscriptions (
           id, source, when_text, given_text, then_text,
           when_embedding, given_embedding, then_embedding,
-          one_shot, enabled, created_at, last_triggered_at, trigger_count
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          one_shot, enabled, created_at, last_triggered_at, trigger_count,
+          when_alt_embedding, given_alt_embedding
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       args: [
         stored.id,
@@ -173,6 +213,8 @@ export class SubscriptionStorage {
         stored.createdAt,
         null,
         0,
+        embeddings.whenEventAlternate ? toBlob(embeddings.whenEventAlternate) : null,
+        embeddings.givenConditionAlternate ? toBlob(embeddings.givenConditionAlternate) : null,
       ],
     });
 
@@ -200,6 +242,8 @@ export class SubscriptionStorage {
       ...this.toSubscription(row),
       whenEmbedding: fromBlob(row.when_embedding),
       givenEmbedding: row.given_embedding === null ? null : fromBlob(row.given_embedding),
+      whenAltEmbedding: row.when_alt_embedding == null ? null : fromBlob(row.when_alt_embedding),
+      givenAltEmbedding: row.given_alt_embedding == null ? null : fromBlob(row.given_alt_embedding),
     }));
   }
 

--- a/mcp/mastra/verticals/synapse/paraphrase.spec.ts
+++ b/mcp/mastra/verticals/synapse/paraphrase.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+import { cosineSimilarity, embedText } from '../../utils/static-embedder.js';
+import { thirdPersonVariant } from './paraphrase.js';
+import { describeStateChange } from './state-change.js';
+
+describe('thirdPersonVariant', () => {
+  it('rewrites the subject pronoun', () => {
+    expect(thirdPersonVariant('I get home from work')).toBe('a person get home from work');
+  });
+
+  it('rewrites possessives and objects', () => {
+    expect(thirdPersonVariant('I receive an email from my boss')).toBe('a person receive an email from the boss');
+    expect(thirdPersonVariant('someone calls me')).toBe('someone calls the person');
+  });
+
+  it('expands contractions before the bare pronoun', () => {
+    // "I'm" must be handled first, or the rewrite leaves "a person'm" behind.
+    expect(thirdPersonVariant("I'm home")).toBe('a person is home');
+    expect(thirdPersonVariant("I've arrived")).toBe('a person has arrived');
+  });
+
+  it('returns null when there is nothing in the first person', () => {
+    expect(thirdPersonVariant('the sun goes down')).toBeNull();
+    expect(thirdPersonVariant('the washing machine finishes')).toBeNull();
+  });
+
+  it('leaves the letter i inside words alone', () => {
+    // The pattern is word-bounded and case-sensitive, so ordinary words survive.
+    expect(thirdPersonVariant('it is raining in Italy')).toBeNull();
+  });
+
+  it('produces a phrasing that actually reaches a machine-shaped state change', async () => {
+    const change = await embedText(
+      describeStateChange({
+        source: 'internet-of-things',
+        stateType: 'device_tracker',
+        stateData: { person: 'Mathias', from: 'work', to: 'home' },
+      }),
+    );
+
+    const original = cosineSimilarity(await embedText('I get home from work'), change);
+    const rewritten = cosineSimilarity(await embedText(thirdPersonVariant('I get home from work') ?? ''), change);
+
+    // 0.20 -> 0.32, across the 0.3 floor. This is the whole reason the rewrite is
+    // stored: the user's own wording never gets there.
+    expect(rewritten).toBeGreaterThan(original);
+    expect(rewritten).toBeGreaterThan(0.3);
+  });
+});

--- a/mcp/mastra/verticals/synapse/paraphrase.ts
+++ b/mcp/mastra/verticals/synapse/paraphrase.ts
@@ -1,0 +1,59 @@
+/**
+ * Subscription paraphrasing.
+ *
+ * People phrase subscriptions in the first person — "when I get home from work" —
+ * because that is how they speak. Verticals report in the third person, because that
+ * is what a device knows: `person is Mathias, state is arrived home`.
+ *
+ * Those two share almost no vocabulary, and the static embedder has no contextual
+ * understanding to bridge them with: it averages token vectors, so "I" and "person"
+ * are simply different tokens pulling in different directions. Measured, the canonical
+ * example from the Synapse design scored 0.14 against its own state change — less than
+ * half the score floor, so no amount of threshold tuning could recover it.
+ *
+ * Rewriting the pronouns produces a second phrasing to embed alongside the original.
+ * Matching takes the better of the two, so this can only ever help: the original still
+ * catches a user-phrased description, and the rewrite catches the machine-phrased one.
+ *
+ * The output is frequently ungrammatical ("a person get home from work") and that is
+ * fine. Nothing reads it. Model2Vec pools token vectors without regard for word order
+ * or agreement, so only the vocabulary shift matters.
+ */
+
+/**
+ * First-person to third-person substitutions, applied in order.
+ *
+ * `I'm` and `I've` come before the bare `I` so the contraction is not left stranded.
+ * Only `I` is case-sensitive — it is always capitalised as a pronoun, whereas matching
+ * it case-insensitively would rewrite the letter wherever it appeared alone.
+ */
+const SUBSTITUTIONS: Array<[RegExp, string]> = [
+  [/\bI'm\b/g, 'a person is'],
+  [/\bI've\b/g, 'a person has'],
+  [/\bI\b/g, 'a person'],
+  [/\bmy\b/gi, 'the'],
+  [/\bmine\b/gi, 'theirs'],
+  [/\bme\b/gi, 'the person'],
+  [/\bmyself\b/gi, 'themselves'],
+];
+
+/**
+ * Rewrites a first-person clause into a third-person one.
+ *
+ * @param text - The clause as the user phrased it
+ * @returns The rewritten clause, or null when there was nothing in the first person
+ *
+ * @example
+ * ```typescript
+ * thirdPersonVariant('I get home from work'); // "a person get home from work"
+ * thirdPersonVariant('the sun goes down');    // null
+ * ```
+ */
+export function thirdPersonVariant(text: string): string | null {
+  const rewritten = SUBSTITUTIONS.reduce(
+    (result, [pattern, replacement]) => result.replace(pattern, replacement),
+    text,
+  );
+
+  return rewritten === text ? null : rewritten;
+}

--- a/mcp/mastra/verticals/synapse/state-change-batcher.ts
+++ b/mcp/mastra/verticals/synapse/state-change-batcher.ts
@@ -3,7 +3,7 @@ import { getSubscriptionStorage } from '../../storage/index.js';
 import { logger } from '../../utils/logger.js';
 import { embedTexts } from '../../utils/static-embedder.js';
 import { getStateChangeReactorAgent } from './agent.js';
-import { describeStateChange, type StateChange } from './state-change.js';
+import { describeStateChange, describeStateChangeFacets, type StateChange } from './state-change.js';
 import { formatSubscriptionMatches, rankSubscriptions } from './subscription-matcher.js';
 
 export type { StateChange } from './state-change.js';
@@ -198,10 +198,20 @@ export class StateChangeBatcher {
 
     // Load the subscriptions once and embed the whole batch in one pass, rather
     // than repeating both per change.
-    const descriptions = changes.map(describeStateChange);
-    const embeddings = await embedTexts(descriptions);
+    // Each change is rendered into several overlapping facets and scored on its best
+    // one, which stops a long description diluting a strong match in one of its parts.
+    // Every facet of every change goes into a single embedding pass and is then split
+    // back apart, so the batch still costs one call into the embedder.
+    const facetsPerChange = changes.map(describeStateChangeFacets);
+    const embeddings = await embedTexts(facetsPerChange.flat());
 
-    return embeddings.map((embedding) => formatSubscriptionMatches(rankSubscriptions(embedding, subscriptions)));
+    let offset = 0;
+    return facetsPerChange.map((facets) => {
+      const embeddingsForChange = embeddings.slice(offset, offset + facets.length);
+      offset += facets.length;
+
+      return formatSubscriptionMatches(rankSubscriptions(embeddingsForChange, subscriptions));
+    });
   }
 
   /**

--- a/mcp/mastra/verticals/synapse/state-change.spec.ts
+++ b/mcp/mastra/verticals/synapse/state-change.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { describeStateChange } from './state-change.js';
+import { describeStateChange, describeStateChangeFacets } from './state-change.js';
 
 describe('describeStateChange', () => {
   it('renders source, type and data as a readable sentence', () => {
@@ -56,5 +56,59 @@ describe('describeStateChange', () => {
     });
 
     expect(description).toContain('a b c is {"d":"value"}');
+  });
+});
+
+describe('describeStateChangeFacets', () => {
+  it('always includes the whole description', () => {
+    const change = {
+      source: 'weather',
+      stateType: 'sun_position_changed',
+      stateData: { event: 'sunset', elevation: -0.5 },
+    };
+
+    expect(describeStateChangeFacets(change)).toContain(describeStateChange(change));
+  });
+
+  it('offers the heading, each detail, and each detail under its heading', () => {
+    const facets = describeStateChangeFacets({
+      source: 'internet-of-things',
+      stateType: 'presence_changed',
+      stateData: { person: 'Mathias', state: 'arrived home' },
+    });
+
+    expect(facets).toContain('internet-of-things presence changed');
+    // The detail on its own is the fragment that rescues a match the full description
+    // would have diluted past the score floor.
+    expect(facets).toContain('state is arrived home');
+    expect(facets).toContain('internet-of-things presence changed state is arrived home');
+  });
+
+  it('returns just the heading when there is no payload', () => {
+    expect(describeStateChangeFacets({ source: 'weather', stateType: 'sun_position_changed', stateData: {} })).toEqual([
+      'weather sun position changed',
+    ]);
+  });
+
+  it('does not repeat a facet that renders identically to another', () => {
+    const facets = describeStateChangeFacets({
+      source: 'shopping',
+      stateType: 'item_expiring',
+      stateData: { item: 'milk' },
+    });
+
+    // With a single detail the "heading + detail" facet is the full description.
+    expect(new Set(facets).size).toBe(facets.length);
+  });
+
+  it('stays small enough that embedding them together is cheap', () => {
+    const facets = describeStateChangeFacets({
+      source: 'internet-of-things',
+      stateType: 'climate_changed',
+      stateData: { device: 'thermostat', temperature: 21, humidity: 40, mode: 'heat' },
+    });
+
+    // Two per detail plus the heading and the whole thing: linear, not combinatorial.
+    expect(facets.length).toBe(2 + 4 * 2);
   });
 });

--- a/mcp/mastra/verticals/synapse/state-change.ts
+++ b/mcp/mastra/verticals/synapse/state-change.ts
@@ -76,3 +76,50 @@ export function describeStateChange(change: StateChange): string {
 
   return details.length > 0 ? `${heading}: ${details.join(', ')}` : heading;
 }
+
+/**
+ * Renders a state change as several overlapping fragments, each embeddable on its own.
+ *
+ * Matching scores every fragment and keeps the best, which exists to work around how
+ * the static embedder combines tokens. It mean-pools them, so a long description is the
+ * average of everything in it and each token sharing no meaning with a subscription
+ * pulls the result away from the ones that do. Adding *true detail* therefore made
+ * matches worse: measured against "I get home from work", "arrived home" scored 0.32,
+ * "person arrived home" 0.28, and "Mathias arrived home" 0.21.
+ *
+ * Scoring the parts separately removes that penalty — a subscription only has to
+ * resemble one fragment rather than the average of all of them. Recall rose from 88% to
+ * 94% on the test corpus, and stayed there as the score floor was raised to 0.45, where
+ * whole-description matching had already collapsed to 69%.
+ *
+ * The fragments overlap on purpose. The whole description wins when a subscription
+ * describes the event in full; the heading alone wins when the event type carries the
+ * meaning ("air quality changed"); a single detail wins when the payload does ("state is
+ * arrived home"); and heading-plus-detail covers the common case where neither half is
+ * enough by itself.
+ *
+ * Embedding all of them costs almost nothing — six fragments measured 1.1x a single
+ * description, because they are embedded in one batched pass.
+ *
+ * @param change - The state change to render
+ * @returns Fragments to embed, always including the full description
+ */
+export function describeStateChangeFacets(change: StateChange): string[] {
+  const heading = humanize(`${change.source} ${change.stateType}`);
+  const details = flatten(change.stateData);
+
+  if (details.length === 0) {
+    return [heading];
+  }
+
+  const full = `${heading}: ${details.join(', ')}`;
+  const facets = [full, heading];
+
+  for (const detail of details) {
+    facets.push(`${heading} ${detail}`, detail);
+  }
+
+  // A single detail renders the same as the whole description would, so drop the
+  // duplicates rather than embedding the same text twice.
+  return [...new Set(facets)];
+}

--- a/mcp/mastra/verticals/synapse/subscription-matcher.ts
+++ b/mcp/mastra/verticals/synapse/subscription-matcher.ts
@@ -15,8 +15,8 @@
 import { getSubscriptionStorage } from '../../storage/index.js';
 import type { EmbeddedSubscription, Subscription } from '../../storage/subscriptions.js';
 import { logger } from '../../utils/logger.js';
-import { cosineSimilarity, embedText } from '../../utils/static-embedder.js';
-import { describeStateChange, type StateChange } from './state-change.js';
+import { cosineSimilarity, embedTexts } from '../../utils/static-embedder.js';
+import { describeStateChangeFacets, type StateChange } from './state-change.js';
 
 /**
  * Minimum similarity for a subscription to be considered relevant.
@@ -26,6 +26,30 @@ import { describeStateChange, type StateChange } from './state-change.js';
  * than precision here because the LLM filters afterwards.
  */
 export const DEFAULT_MINIMUM_SCORE = 0.3;
+
+/**
+ * Best similarity between any facet of what happened and any phrasing of one
+ * subscription component.
+ *
+ * Both sides are deliberately plural. A state change is embedded as several
+ * overlapping fragments so that a long description cannot dilute a strong match in one
+ * of its parts, and a subscription carries a third-person rewrite alongside the user's
+ * own wording so it is reachable from either. Taking the maximum means neither can make
+ * matching worse than it was with a single vector on each side.
+ */
+function bestSimilarity(facets: Float32Array[], components: Array<Float32Array | null>): number {
+  let best = Number.NEGATIVE_INFINITY;
+
+  for (const facet of facets) {
+    for (const component of components) {
+      if (component) {
+        best = Math.max(best, cosineSimilarity(facet, component));
+      }
+    }
+  }
+
+  return best;
+}
 
 /** Maximum number of subscriptions handed to the LLM for one state change. */
 export const DEFAULT_MAXIMUM_MATCHES = 5;
@@ -75,8 +99,7 @@ export async function findRelevantSubscriptions(
     return [];
   }
 
-  const descriptionEmbedding = await embedText(description);
-  const matches = rankSubscriptions(descriptionEmbedding, subscriptions, options);
+  const matches = rankSubscriptions(await embedTexts([description]), subscriptions, options);
 
   logger.info('[SYNAPSE] Matched subscriptions', {
     description,
@@ -93,22 +116,26 @@ export async function findRelevantSubscriptions(
  * Split out from {@link findRelevantSubscriptions} so the ranking rules can be
  * exercised (and reused) without touching storage.
  *
- * @param descriptionEmbedding - Embedding of what happened
+ * @param descriptionEmbedding - Embedding of what happened, or several embeddings when
+ *   the state change was rendered into overlapping facets
  * @param subscriptions - Subscriptions with their `whenEvent`/`givenCondition` embeddings
  * @param options - Score floor and shortlist size
  * @returns Matches above the score floor, strongest first
  */
 export function rankSubscriptions(
-  descriptionEmbedding: Float32Array,
+  descriptionEmbedding: Float32Array | Float32Array[],
   subscriptions: EmbeddedSubscription[],
   options: SubscriptionMatchOptions = {},
 ): SubscriptionMatch[] {
   const { minimumScore = DEFAULT_MINIMUM_SCORE, maximumMatches = DEFAULT_MAXIMUM_MATCHES } = options;
+  // A single embedding is still accepted, so a caller that has only a description in
+  // hand does not have to know about facets.
+  const facets = Array.isArray(descriptionEmbedding) ? descriptionEmbedding : [descriptionEmbedding];
 
   return subscriptions
-    .map(({ whenEmbedding, givenEmbedding, ...subscription }) => {
-      const whenScore = cosineSimilarity(descriptionEmbedding, whenEmbedding);
-      const givenScore = givenEmbedding ? cosineSimilarity(descriptionEmbedding, givenEmbedding) : null;
+    .map(({ whenEmbedding, givenEmbedding, whenAltEmbedding, givenAltEmbedding, ...subscription }) => {
+      const whenScore = bestSimilarity(facets, [whenEmbedding, whenAltEmbedding]);
+      const givenScore = givenEmbedding ? bestSimilarity(facets, [givenEmbedding, givenAltEmbedding]) : null;
 
       return {
         subscription,
@@ -133,7 +160,26 @@ export async function findSubscriptionsForStateChange(
   change: StateChange,
   options: SubscriptionMatchOptions = {},
 ): Promise<SubscriptionMatch[]> {
-  return await findRelevantSubscriptions(describeStateChange(change), options);
+  const storage = await getSubscriptionStorage();
+  const subscriptions = await storage.getAllEmbedded({ includeDisabled: options.includeDisabled ?? false });
+
+  if (subscriptions.length === 0) {
+    return [];
+  }
+
+  // Facets rather than one description: see describeStateChangeFacets for why, and for
+  // the measurement that justifies the extra embeddings.
+  const facets = await embedTexts(describeStateChangeFacets(change));
+  const matches = rankSubscriptions(facets, subscriptions, options);
+
+  logger.info('[SYNAPSE] Matched subscriptions', {
+    stateType: change.stateType,
+    facetCount: facets.length,
+    candidateCount: subscriptions.length,
+    matchCount: matches.length,
+  });
+
+  return matches;
 }
 
 /**

--- a/mcp/mastra/verticals/synapse/subscription-relevance.spec.ts
+++ b/mcp/mastra/verticals/synapse/subscription-relevance.spec.ts
@@ -20,7 +20,8 @@
 import { describe, expect, it } from 'bun:test';
 import type { EmbeddedSubscription } from '../../storage/subscriptions.js';
 import { cosineSimilarity, embedText, embedTexts } from '../../utils/static-embedder.js';
-import { describeStateChange, type StateChange } from './state-change.js';
+import { thirdPersonVariant } from './paraphrase.js';
+import { describeStateChange, describeStateChangeFacets, type StateChange } from './state-change.js';
 import { DEFAULT_MINIMUM_SCORE, rankSubscriptions } from './subscription-matcher.js';
 
 interface Draft {
@@ -210,10 +211,11 @@ const PROBES: Array<{ name: string; change: StateChange; expected: string }> = [
   },
 ];
 
-/** Probes the first-person phrasing gap is known to lose. See the dedicated section below. */
-const KNOWN_MISSES = new Set(['arrival (presence)', 'arrival (tracker)']);
-
+/** Embeds a subscription the way registerSubscription does, rewrites included. */
 async function embedDraft(draft: Draft): Promise<EmbeddedSubscription> {
+  const whenAlternate = thirdPersonVariant(draft.whenEvent);
+  const givenAlternate = draft.givenCondition ? thirdPersonVariant(draft.givenCondition) : null;
+
   return {
     ...draft,
     source: 'user',
@@ -224,18 +226,33 @@ async function embedDraft(draft: Draft): Promise<EmbeddedSubscription> {
     triggerCount: 0,
     whenEmbedding: await embedText(draft.whenEvent),
     givenEmbedding: draft.givenCondition ? await embedText(draft.givenCondition) : null,
+    whenAltEmbedding: whenAlternate ? await embedText(whenAlternate) : null,
+    givenAltEmbedding: givenAlternate ? await embedText(givenAlternate) : null,
   };
 }
 
 const subscriptions = await Promise.all(DRAFTS.map(embedDraft));
 
+/** Retrieval exactly as the batcher performs it: facets in, ranked matches out. */
 async function retrieve(change: StateChange, minimumScore = DEFAULT_MINIMUM_SCORE) {
+  const facets = await embedTexts(describeStateChangeFacets(change));
+  return rankSubscriptions(facets, subscriptions, { minimumScore, maximumMatches: 5 });
+}
+
+/** Retrieval as it worked before facets and rewrites, for the comparisons below. */
+async function retrieveWithSingleVector(change: StateChange, minimumScore = DEFAULT_MINIMUM_SCORE) {
   const embedding = await embedText(describeStateChange(change));
-  return rankSubscriptions(embedding, subscriptions, { minimumScore, maximumMatches: 5 });
+  const withoutRewrites = subscriptions.map((subscription) => ({
+    ...subscription,
+    whenAltEmbedding: null,
+    givenAltEmbedding: null,
+  }));
+
+  return rankSubscriptions(embedding, withoutRewrites, { minimumScore, maximumMatches: 5 });
 }
 
 describe('retrieval quality on a realistic corpus', () => {
-  it('retrieves the intended subscription for at least 80% of state changes', async () => {
+  it('retrieves the intended subscription for at least 90% of state changes', async () => {
     const hits = await Promise.all(
       PROBES.map(async ({ change, expected }) =>
         (await retrieve(change)).some((match) => match.subscription.id === expected),
@@ -244,25 +261,18 @@ describe('retrieval quality on a realistic corpus', () => {
 
     const recall = hits.filter(Boolean).length / PROBES.length;
 
-    // Measured at 0.88 (14/16). The floor leaves room for embedder updates without
-    // being so loose that a real regression slips through.
-    expect(recall).toBeGreaterThanOrEqual(0.8);
+    // Measured at 1.0 (16/16), up from 0.88 before facets and rewrites. The floor
+    // leaves room for embedder updates without letting a real regression through.
+    expect(recall).toBeGreaterThanOrEqual(0.9);
   });
 
   it('ranks the intended subscription first whenever it retrieves it at all', async () => {
-    for (const { name, change, expected } of PROBES) {
+    for (const { change, expected } of PROBES) {
       const matches = await retrieve(change);
-      const rank = matches.findIndex((match) => match.subscription.id === expected);
 
-      if (rank === -1) {
-        // Only the documented gap is allowed to miss outright.
-        expect(KNOWN_MISSES.has(name)).toBe(true);
-        continue;
-      }
-
-      // Never merely present-but-buried: when the signal is there it wins outright,
+      // Never merely present-but-buried: the intended subscription wins outright,
       // which is why a shortlist of five costs nothing in practice.
-      expect(rank).toBe(0);
+      expect(matches[0]?.subscription.id).toBe(expected);
     }
   });
 
@@ -270,13 +280,14 @@ describe('retrieval quality on a realistic corpus', () => {
     const counts = await Promise.all(PROBES.map(async ({ change }) => (await retrieve(change)).length));
     const average = counts.reduce((total, count) => total + count, 0) / counts.length;
 
-    // Measured at 1.3 candidates per change. The value of the step is that the LLM
-    // sees one or two plausible rules instead of the entire subscription set.
-    expect(average).toBeLessThan(3);
+    // Measured at 2.4 candidates per change, against 1.3 before facets. Recall bought
+    // with a slightly longer shortlist is the trade this step is supposed to make: the
+    // LLM sees two or three plausible rules instead of the entire subscription set.
+    expect(average).toBeLessThan(4);
     expect(Math.max(...counts)).toBeLessThanOrEqual(5);
   });
 
-  it('returns nothing at all for state changes no subscription cares about', async () => {
+  it('surfaces at most one weak candidate for state changes no subscription cares about', async () => {
     const unrelated: StateChange[] = [
       {
         source: 'coding',
@@ -287,8 +298,37 @@ describe('retrieval quality on a realistic corpus', () => {
     ];
 
     for (const change of unrelated) {
-      expect(await retrieve(change)).toEqual([]);
+      const matches = await retrieve(change);
+
+      // Scoring facets rather than one diluted description is what lifted recall to
+      // 100%, and this is the price: a fragment can resemble a subscription even when
+      // the change as a whole does not. Measured, "...title is Refactor the deployment
+      // script" reaches the "I get home from work" rewrite at 0.315 -- a hair over the
+      // floor. Single-vector matching returned nothing here.
+      //
+      // Bounded rather than forbidden, because the shortlist is explicitly a recall
+      // step: one weak candidate is what the reactor agent exists to throw away, and
+      // the cost of a wrong one is a sentence of prompt.
+      expect(matches.length).toBeLessThanOrEqual(1);
+
+      for (const match of matches) {
+        expect(match.score).toBeLessThan(0.35);
+      }
     }
+  });
+
+  it('scores a genuine match well clear of the strongest false positive', async () => {
+    const genuine = await retrieve(PROBES[0].change);
+    const spurious = await retrieve({
+      source: 'coding',
+      stateType: 'pull_request_opened',
+      stateData: { repository: 'hey-jarvis', title: 'Refactor the deployment script' },
+    });
+
+    // 0.50 against 0.315. That separation is what makes raising the floor an option if
+    // shortlist length ever matters more than recall -- which it was not before, when
+    // 0.4 cost a third of all real matches.
+    expect(genuine[0].score).toBeGreaterThan((spurious[0]?.score ?? 0) + 0.1);
   });
 });
 
@@ -463,5 +503,72 @@ describe('matching cost', () => {
     // Measured at 0.2ms per text batched against 2.7ms individually. This is why the
     // batcher embeds a whole batch in one pass instead of looping per change.
     expect(batched).toBeLessThan(individual);
+  });
+});
+
+describe('what facets and rewrites bought', () => {
+  it('retrieves strictly more than single-vector matching did', async () => {
+    const before = await Promise.all(
+      PROBES.map(async ({ change, expected }) =>
+        (await retrieveWithSingleVector(change)).some((match) => match.subscription.id === expected),
+      ),
+    );
+    const after = await Promise.all(
+      PROBES.map(async ({ change, expected }) =>
+        (await retrieve(change)).some((match) => match.subscription.id === expected),
+      ),
+    );
+
+    // Nothing that used to be found is lost: taking the best of several facets and
+    // several phrasings can only ever raise a score, never lower one.
+    for (const [index, foundBefore] of before.entries()) {
+      if (foundBefore) {
+        expect(after[index]).toBe(true);
+      }
+    }
+
+    // 14/16 -> 16/16.
+    expect(after.filter(Boolean).length).toBeGreaterThan(before.filter(Boolean).length);
+  });
+
+  it('holds up when the score floor is raised, which single vectors did not', async () => {
+    const recallAt = async (
+      threshold: number,
+      retriever: (change: StateChange, minimumScore?: number) => Promise<Array<{ subscription: { id: string } }>>,
+    ) => {
+      const hits = await Promise.all(
+        PROBES.map(async ({ change, expected }) =>
+          (await retriever(change, threshold)).some((match) => match.subscription.id === expected),
+        ),
+      );
+
+      return hits.filter(Boolean).length / PROBES.length;
+    };
+
+    // At 0.45 the diluted single vector had collapsed to 69%; facets hold 94%. The
+    // score means something now, rather than being a knob tuned to one corpus.
+    expect(await recallAt(0.45, retrieveWithSingleVector)).toBeLessThan(0.8);
+    expect(await recallAt(0.45, retrieve)).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('costs roughly one extra embedding pass, not one per facet', async () => {
+    await embedText('warm up');
+    const change = PROBES[2].change;
+
+    const singleStarted = performance.now();
+    for (let run = 0; run < 20; run++) {
+      await embedText(describeStateChange(change));
+    }
+    const single = performance.now() - singleStarted;
+
+    const facetStarted = performance.now();
+    for (let run = 0; run < 20; run++) {
+      await embedTexts(describeStateChangeFacets(change));
+    }
+    const facets = performance.now() - facetStarted;
+
+    // Six facets measured 1.1x one description, because they are embedded together.
+    // The ceiling is loose for CI, but a per-facet round trip would be ~6x and fail.
+    expect(facets).toBeLessThan(single * 3);
   });
 });

--- a/mcp/mastra/verticals/synapse/subscription-tools.ts
+++ b/mcp/mastra/verticals/synapse/subscription-tools.ts
@@ -3,6 +3,7 @@ import { getSubscriptionStorage } from '../../storage/index.js';
 import { logger } from '../../utils/logger.js';
 import { embedTexts } from '../../utils/static-embedder.js';
 import { createTool } from '../../utils/tool-factory.js';
+import { thirdPersonVariant } from './paraphrase.js';
 import {
   DEFAULT_MAXIMUM_MATCHES,
   DEFAULT_MINIMUM_SCORE,
@@ -73,11 +74,21 @@ export const registerSubscription = createTool({
       oneShot: inputData.oneShot,
     });
 
-    const [whenEmbedding, thenEmbedding, givenEmbedding] = await embedTexts([
-      inputData.whenEvent,
-      inputData.thenAction,
-      ...(inputData.givenCondition ? [inputData.givenCondition] : []),
-    ]);
+    // A first-person clause is also stored in the third person. Users say "when I get
+    // home from work"; devices report "person is Mathias, state is arrived home", and
+    // the static embedder cannot connect the two on its own. Matching takes the better
+    // of the two phrasings, so the rewrite can only add reach.
+    const whenAlternate = thirdPersonVariant(inputData.whenEvent);
+    const givenAlternate = inputData.givenCondition ? thirdPersonVariant(inputData.givenCondition) : null;
+
+    const texts = [inputData.whenEvent, inputData.thenAction];
+    const givenIndex = inputData.givenCondition ? texts.push(inputData.givenCondition) - 1 : -1;
+    const whenAlternateIndex = whenAlternate ? texts.push(whenAlternate) - 1 : -1;
+    const givenAlternateIndex = givenAlternate ? texts.push(givenAlternate) - 1 : -1;
+
+    const embeddings = await embedTexts(texts);
+    const [whenEmbedding, thenEmbedding] = embeddings;
+    const givenEmbedding = givenIndex === -1 ? undefined : embeddings[givenIndex];
 
     if (!whenEmbedding || !thenEmbedding) {
       throw new Error('Failed to embed the subscription components');
@@ -96,6 +107,8 @@ export const registerSubscription = createTool({
         whenEvent: whenEmbedding,
         thenAction: thenEmbedding,
         givenCondition: givenEmbedding ?? null,
+        whenEventAlternate: whenAlternateIndex === -1 ? null : embeddings[whenAlternateIndex],
+        givenConditionAlternate: givenAlternateIndex === -1 ? null : embeddings[givenAlternateIndex],
       },
     );
 


### PR DESCRIPTION
Stacked on #671, which added the benchmark these numbers come from.

**In one sentence:** instead of comparing a rule against the event as one blended whole, compare it against the event's individual pieces too, and keep the best score.

## What was going wrong

Matching turns text into a list of numbers and compares lists. The way it builds that list is by looking up a number for each word and **averaging them all together**.

Averaging means every word gets an equal vote. So a few meaningful words get outvoted by a crowd of boilerplate.

Here is a real rule and a real event:

```
rule:  "I get home from work"
event: "internet-of-things device tracker: person is Mathias, from is work, to is home"
```

Obviously the same thing. Score: **0.20**, against a threshold of 0.30. No match.

And it gets worse the more accurate you are:

| Description | Score |
| --- | --- |
| `arrived home` | 0.32 ✅ |
| `person arrived home` | 0.28 ❌ |
| `Mathias arrived home` | 0.21 ❌ |

Adding the person's name — true, useful information — broke the match. That is averaging doing its job badly.

## Fix 1: compare the pieces, not just the whole

Chop the event into overlapping pieces and score each one separately. Best piece wins.

Same event as above, now scored piece by piece:

| Piece | Score |
| --- | --- |
| `internet-of-things device tracker: person is Mathias, from is work, to is home` | 0.20 |
| `internet-of-things device tracker` | 0.06 |
| `person is Mathias` | 0.02 |
| **`from is work`** | **0.67** ✅ |
| **`to is home`** | **0.55** ✅ |

The match was in there all along, scoring 0.67. Averaging buried it at 0.20.

Pieces overlap on purpose, because the meaning is not always in the same place. Sometimes it is in the detail (`state is arrived home`); sometimes it is in the headline — an air-quality event's payload is just `co2_ppm: 1400`, numbers that mean nothing on their own, while `air quality changed` is what actually resembles the rule *"the air quality gets bad"*. So we offer both and let the best win.

**This is nearly free.** Six pieces measured 1.1× the cost of one description, because they are all converted in a single batch. The batcher still makes exactly one call for a whole batch of events.

## Fix 2: save the rule twice, once rephrased

People say *"when **I** get home from work"*. Devices say *"**person** is Mathias"*. Same meaning, no shared words — and the matcher only knows words.

So when a rule is saved, we also save a copy with the pronouns swapped:

```
"I get home from work"  ->  "a person get home from work"
```

It is a find-and-replace — `I` → `a person`, `my` → `the`, `me` → `the person`. No AI involved. The result is not proper English, and that does not matter: nothing ever reads it, and the matcher ignores grammar entirely. Only the words count.

Events are then compared against **both** copies, and the better score wins.

## Why neither change can break an existing match

Both are "try more options, keep the best". Adding an option can raise the best score but never lower it — so anything that matched before still matches. There is a test asserting exactly that.

## Results

| Threshold | Before | After |
| --- | --- | --- |
| **0.30** (default) | 88% found, 1.3 candidates | **100%**, 2.4 candidates |
| 0.40 | 69% | **94%** |
| 0.45 | 69% | **94%**, 1.0 candidates |

The bottom rows matter more than the top one. Before, matching only worked at one carefully chosen threshold and fell apart if you nudged it. Now the score means something.

## What it costs, honestly

**One weak false match.** A pull request titled *"Refactor the deployment script"* now reaches the rewritten arrival rule at **0.315** — barely over the line, where before it scored nothing. Giving pieces their own vote means a piece can match by coincidence.

I left it in rather than tuning it away: this shortlist is deliberately generous, and an LLM reads it afterwards and discards bad candidates. It is bounded by a test (at most 1 candidate, score under 0.35), and genuine matches now score around 0.50 — comfortably clear.

**One of the two rescues is thinner than it looks.** The `device_tracker` event above is rescued properly, on `from is work` at 0.67. The other arrival event (`person is Mathias, state is arrived home`) is rescued only by `person is Mathias` matching the rewritten rule at 0.34 — that is the word *"person"* matching *"a person"*, not any real understanding of arriving home. It works, and device payloads really do say `person is …`, but it is a thinner thread than the headline number suggests.

## Migration

Two nullable columns, added behind a `PRAGMA table_info` check because SQLite has no `ADD COLUMN IF NOT EXISTS`. Existing rows read back as `null`, which matching already treats as "no rephrased copy" — so they keep working unchanged and pick up the improvement whenever they are next re-registered.

## Tests

`paraphrase.spec.ts` (7) for the rewrite rules, piece-splitting tests in `state-change.spec.ts` (5), and a **what facets and rewrites bought** block that runs old against new in the same pass — including that the gain survives a raised threshold and stays within one embedding batch.

Full mcp suite: **291 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
