### PR TITLE
feat(synapse): give every subscription an end, and prune the ones that reach it

### DIFF
--- a/mcp/mastra/storage/subscriptions.spec.ts
+++ b/mcp/mastra/storage/subscriptions.spec.ts
@@ -157,3 +157,132 @@ describe('SubscriptionStorage', () => {
     expect(await storage.remove(stored.id)).toBe(false);
   });
 });
+
+describe('SubscriptionStorage expiry', () => {
+  /** A moment far enough back or forward that clock skew cannot reach it. */
+  const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  async function add(overrides: Partial<Parameters<typeof storage.add>[0]> = {}) {
+    return await storage.add(
+      {
+        source: 'user',
+        whenEvent: 'the sun goes down',
+        thenAction: 'close the blinds',
+        ...overrides,
+      },
+      await embeddingsFor('the sun goes down', 'close the blinds'),
+    );
+  }
+
+  describe('a firing budget', () => {
+    it('stays armed until the budget is used up', async () => {
+      const stored = await add({ maxTriggerCount: 3 });
+      expect(stored.maxTriggerCount).toBe(3);
+
+      expect((await storage.markTriggered(stored.id))?.enabled).toBe(true);
+      expect((await storage.markTriggered(stored.id))?.enabled).toBe(true);
+
+      const spent = await storage.markTriggered(stored.id);
+      expect(spent?.triggerCount).toBe(3);
+      expect(spent?.enabled).toBe(false);
+    });
+
+    it('is what oneShot means, so the two cannot disagree', async () => {
+      const stored = await add({ oneShot: true });
+
+      // oneShot is the older spelling of a budget of one. Recording it as such keeps a
+      // single rule for "spent" rather than two that can drift apart.
+      expect(stored.maxTriggerCount).toBe(1);
+      expect((await storage.markTriggered(stored.id))?.enabled).toBe(false);
+    });
+
+    it('never runs out when no budget was set', async () => {
+      const stored = await add({ expiresAt: future });
+      expect(stored.maxTriggerCount).toBeNull();
+
+      for (let firing = 0; firing < 5; firing++) {
+        expect((await storage.markTriggered(stored.id))?.enabled).toBe(true);
+      }
+    });
+  });
+
+  describe('a deadline', () => {
+    it('hides an expired subscription from matching and from listing', async () => {
+      await add({ expiresAt: past });
+
+      expect(await storage.list()).toEqual([]);
+      expect(await storage.getAllEmbedded()).toEqual([]);
+    });
+
+    it('leaves a subscription alone until its deadline passes', async () => {
+      const stored = await add({ expiresAt: future });
+
+      expect((await storage.list()).map((subscription) => subscription.id)).toEqual([stored.id]);
+      expect(stored.expiresAt).toBe(future);
+    });
+
+    it('still shows expired subscriptions when explicitly asked for everything', async () => {
+      const stored = await add({ expiresAt: past });
+
+      // includeDisabled is "show me the lot", which is what a user asking why something
+      // stopped happening needs to see.
+      const all = await storage.list({ includeDisabled: true });
+      expect(all.map((subscription) => subscription.id)).toEqual([stored.id]);
+    });
+  });
+
+  describe('pruneExpired', () => {
+    it('deletes subscriptions whose deadline has passed', async () => {
+      const doomed = await add({ expiresAt: past });
+      const kept = await add({ expiresAt: future });
+
+      const removed = await storage.pruneExpired();
+
+      expect(removed.map((subscription) => subscription.id)).toEqual([doomed.id]);
+      expect(await storage.get(doomed.id)).toBeNull();
+      expect(await storage.get(kept.id)).not.toBeNull();
+    });
+
+    it('deletes subscriptions that have used up their firings', async () => {
+      const stored = await add({ maxTriggerCount: 1 });
+      await storage.markTriggered(stored.id);
+
+      expect((await storage.pruneExpired()).map((subscription) => subscription.id)).toEqual([stored.id]);
+      expect(await storage.get(stored.id)).toBeNull();
+    });
+
+    it('leaves a subscription that was merely paused', async () => {
+      const stored = await add({ expiresAt: future });
+      await storage.setEnabled(stored.id, false);
+
+      // Disabling by hand is a pause, and a pause should not quietly become a deletion.
+      expect(await storage.pruneExpired()).toEqual([]);
+      expect(await storage.get(stored.id)).not.toBeNull();
+    });
+
+    it('leaves subscriptions with no end at all, which predate the columns', async () => {
+      const stored = await add();
+
+      expect(stored.maxTriggerCount).toBeNull();
+      expect(stored.expiresAt).toBeNull();
+      expect(await storage.pruneExpired()).toEqual([]);
+      expect(await storage.get(stored.id)).not.toBeNull();
+    });
+
+    it('reports nothing when there is nothing to do', async () => {
+      await add({ expiresAt: future });
+
+      expect(await storage.pruneExpired()).toEqual([]);
+    });
+
+    it('judges deadlines against a supplied moment', async () => {
+      const stored = await add({ expiresAt: future });
+
+      // Nothing to prune now, but everything to prune tomorrow.
+      expect(await storage.pruneExpired()).toEqual([]);
+      const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      expect((await storage.pruneExpired(tomorrow)).map((subscription) => subscription.id)).toEqual([stored.id]);
+    });
+  });
+});

--- a/mcp/mastra/storage/subscriptions.ts
+++ b/mcp/mastra/storage/subscriptions.ts
@@ -30,6 +30,18 @@ export interface NewSubscription extends SubscriptionComponents {
   source: string;
   /** When true, the subscription is disabled the first time it fires. */
   oneShot?: boolean;
+  /**
+   * How many times this may fire before it is spent. Null means no limit.
+   *
+   * A budget rather than a flag, so "remind me for the next three deliveries" is
+   * expressible without registering three subscriptions.
+   */
+  maxTriggerCount?: number | null;
+  /**
+   * ISO timestamp after which this stops matching and becomes eligible for deletion.
+   * Null means no deadline.
+   */
+  expiresAt?: string | null;
 }
 
 export interface Subscription extends SubscriptionComponents {
@@ -40,7 +52,14 @@ export interface Subscription extends SubscriptionComponents {
   createdAt: string;
   lastTriggeredAt: string | null;
   triggerCount: number;
+  /** Firing budget, or null when the subscription may fire indefinitely. */
+  maxTriggerCount: number | null;
+  /** Deadline as an ISO timestamp, or null when the subscription has none. */
+  expiresAt: string | null;
 }
+
+/** Why a subscription is finished, for logging and for telling the user. */
+export type SubscriptionExpiryReason = 'spent' | 'expired';
 
 /**
  * A subscription plus the embeddings of its components, as used by the matcher.
@@ -115,11 +134,40 @@ export class SubscriptionStorage {
         enabled INTEGER NOT NULL DEFAULT 1,
         created_at TEXT NOT NULL,
         last_triggered_at TEXT,
-        trigger_count INTEGER NOT NULL DEFAULT 0
+        trigger_count INTEGER NOT NULL DEFAULT 0,
+        max_trigger_count INTEGER,
+        expires_at TEXT
       )
     `);
 
+    // Databases created before subscriptions could expire are missing those columns.
+    // Adding them leaves existing rows NULL, which every check below reads as "no
+    // limit" -- so an old subscription behaves exactly as it did.
+    await this.addMissingColumns();
+
     this.initialized = true;
+  }
+
+  /**
+   * Adds any columns a database predating them is missing.
+   *
+   * SQLite has no `ADD COLUMN IF NOT EXISTS`, so the current columns are read back
+   * from `PRAGMA table_info` and only the absent ones are added.
+   */
+  private async addMissingColumns(): Promise<void> {
+    const existing = await this.client.execute('PRAGMA table_info(synapse_subscriptions)');
+    const columnNames = new Set(existing.rows.map((row) => String(row.name)));
+
+    const additions: Array<[string, string]> = [
+      ['max_trigger_count', 'INTEGER'],
+      ['expires_at', 'TEXT'],
+    ];
+
+    for (const [column, type] of additions) {
+      if (!columnNames.has(column)) {
+        await this.client.execute(`ALTER TABLE synapse_subscriptions ADD COLUMN ${column} ${type}`);
+      }
+    }
   }
 
   /**
@@ -149,6 +197,10 @@ export class SubscriptionStorage {
       createdAt: new Date().toISOString(),
       lastTriggeredAt: null,
       triggerCount: 0,
+      // oneShot is the older spelling of a one-firing budget. Folding it in here keeps
+      // a single rule for when a subscription is spent, rather than two that can drift.
+      maxTriggerCount: subscription.maxTriggerCount ?? (subscription.oneShot ? 1 : null),
+      expiresAt: subscription.expiresAt ?? null,
     };
 
     await this.client.execute({
@@ -156,8 +208,9 @@ export class SubscriptionStorage {
         INSERT INTO synapse_subscriptions (
           id, source, when_text, given_text, then_text,
           when_embedding, given_embedding, then_embedding,
-          one_shot, enabled, created_at, last_triggered_at, trigger_count
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          one_shot, enabled, created_at, last_triggered_at, trigger_count,
+          max_trigger_count, expires_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       args: [
         stored.id,
@@ -173,6 +226,8 @@ export class SubscriptionStorage {
         stored.createdAt,
         null,
         0,
+        stored.maxTriggerCount,
+        stored.expiresAt,
       ],
     });
 
@@ -190,11 +245,17 @@ export class SubscriptionStorage {
   async getAllEmbedded(options: { includeDisabled?: boolean } = {}): Promise<EmbeddedSubscription[]> {
     await this.initialize();
 
-    const result = await this.client.execute(
-      options.includeDisabled
+    // A subscription past its deadline is filtered out here as well as being pruned,
+    // so it stops matching the moment it expires rather than the next time something
+    // happens to run the prune.
+    const result = await this.client.execute({
+      sql: options.includeDisabled
         ? 'SELECT * FROM synapse_subscriptions ORDER BY created_at ASC'
-        : 'SELECT * FROM synapse_subscriptions WHERE enabled = 1 ORDER BY created_at ASC',
-    );
+        : `SELECT * FROM synapse_subscriptions
+           WHERE enabled = 1 AND (expires_at IS NULL OR expires_at > ?)
+           ORDER BY created_at ASC`,
+      args: options.includeDisabled ? [] : [new Date().toISOString()],
+    });
 
     return result.rows.map((row) => ({
       ...this.toSubscription(row),
@@ -211,11 +272,14 @@ export class SubscriptionStorage {
   async list(options: { includeDisabled?: boolean } = {}): Promise<Subscription[]> {
     await this.initialize();
 
-    const result = await this.client.execute(
-      options.includeDisabled
+    const result = await this.client.execute({
+      sql: options.includeDisabled
         ? 'SELECT * FROM synapse_subscriptions ORDER BY created_at ASC'
-        : 'SELECT * FROM synapse_subscriptions WHERE enabled = 1 ORDER BY created_at ASC',
-    );
+        : `SELECT * FROM synapse_subscriptions
+           WHERE enabled = 1 AND (expires_at IS NULL OR expires_at > ?)
+           ORDER BY created_at ASC`,
+      args: options.includeDisabled ? [] : [new Date().toISOString()],
+    });
 
     return result.rows.map((row) => this.toSubscription(row));
   }
@@ -252,6 +316,11 @@ export class SubscriptionStorage {
     }
 
     const triggeredAt = new Date().toISOString();
+    const triggerCount = existing.triggerCount + 1;
+
+    // Spent when the firing budget is used up. oneShot is the older spelling of a
+    // budget of one and is still honoured for rows written before the column existed.
+    const spent = existing.oneShot || (existing.maxTriggerCount !== null && triggerCount >= existing.maxTriggerCount);
 
     await this.client.execute({
       sql: `
@@ -259,15 +328,57 @@ export class SubscriptionStorage {
         SET last_triggered_at = ?, trigger_count = trigger_count + 1, enabled = ?
         WHERE id = ?
       `,
-      args: [triggeredAt, existing.oneShot ? 0 : 1, id],
+      args: [triggeredAt, spent ? 0 : 1, id],
     });
 
     return {
       ...existing,
-      enabled: !existing.oneShot,
+      enabled: !spent,
       lastTriggeredAt: triggeredAt,
-      triggerCount: existing.triggerCount + 1,
+      triggerCount,
     };
+  }
+
+  /**
+   * Deletes subscriptions that can never fire again.
+   *
+   * That is either of two things: the deadline has passed, or the firing budget is
+   * used up. Both are permanent, so the rows are removed rather than disabled —
+   * a disabled subscription is one a user might re-arm, whereas these are finished.
+   *
+   * Disabling by hand is left alone: `setEnabled(id, false)` is a pause, and pausing
+   * something should not eventually delete it.
+   *
+   * @param now - The moment to judge deadlines against, for testing. Defaults to now.
+   * @returns The subscriptions that were deleted, so the caller can say what went
+   */
+  async pruneExpired(now: Date = new Date()): Promise<Subscription[]> {
+    await this.initialize();
+
+    const timestamp = now.toISOString();
+    const doomed = await this.client.execute({
+      sql: `
+        SELECT * FROM synapse_subscriptions
+        WHERE (expires_at IS NOT NULL AND expires_at <= ?)
+           OR (max_trigger_count IS NOT NULL AND trigger_count >= max_trigger_count)
+      `,
+      args: [timestamp],
+    });
+
+    if (doomed.rows.length === 0) {
+      return [];
+    }
+
+    await this.client.execute({
+      sql: `
+        DELETE FROM synapse_subscriptions
+        WHERE (expires_at IS NOT NULL AND expires_at <= ?)
+           OR (max_trigger_count IS NOT NULL AND trigger_count >= max_trigger_count)
+      `,
+      args: [timestamp],
+    });
+
+    return doomed.rows.map((row) => this.toSubscription(row));
   }
 
   /**
@@ -323,6 +434,8 @@ export class SubscriptionStorage {
       createdAt: String(row.created_at),
       lastTriggeredAt: row.last_triggered_at === null ? null : String(row.last_triggered_at),
       triggerCount: Number(row.trigger_count),
+      maxTriggerCount: row.max_trigger_count == null ? null : Number(row.max_trigger_count),
+      expiresAt: row.expires_at == null ? null : String(row.expires_at),
     };
   }
 }

--- a/mcp/mastra/verticals/synapse/agent.ts
+++ b/mcp/mastra/verticals/synapse/agent.ts
@@ -43,6 +43,7 @@ The user registers subscriptions with a Given/When/Then structure:
 Examples:
 - "When the sun goes down (WHEN), if the lights are on (GIVEN), close the blinds (THEN)."
 - "The next time I get home from work (WHEN), turn on the lights (THEN)." — no GIVEN, and one-shot.
+- "For the next three mornings (WHEN the alarm goes off), tell me the traffic (THEN)." — \`maxTriggerCount\` of 3.
 
 Every state change you receive arrives with a shortlist of candidate subscriptions. Those candidates were retrieved by comparing the state change against the WHEN and GIVEN parts using vector similarity, so they are cheap guesses and often wrong. You are the filter:
 1. A candidate only fires if its WHEN genuinely describes what just happened — not merely a related topic.
@@ -51,6 +52,14 @@ Every state change you receive arrives with a shortlist of candidate subscriptio
 4. Ignore candidates that do not fire. A high similarity score is not permission to act.
 
 When the user expresses a new interest ("let me know when...", "next time X happens, do Y"), call registerSubscription with the components split out, setting oneShot for "the next time" style requests. Use listSubscriptions to review what is being watched and removeSubscription / setSubscriptionEnabled to retire or pause one.
+
+**Every subscription must say how it ends.** registerSubscription refuses one that does not, because a subscription with no end is scored against every state change from now on and nothing ever clears it away. Give it either:
+- \`maxTriggerCount\`: how many times it may fire. Use it when the request has a natural count — "for the next three deliveries" is 3, and "the next time" is oneShot, which already means 1.
+- \`expiresAt\`: an ISO timestamp after which it lapses. Use it for anything tied to a date ("until I'm back from holiday on the 8th").
+
+Both may be set, in which case whichever comes first ends it. For an open-ended request like "whenever the doorbell rings", there is no natural count or date — pick a generous \`expiresAt\`, six months or so, rather than leaving it unbounded. The user can always renew it, and an interest they have forgotten about is usually one they no longer hold.
+
+Lapsed subscriptions stop matching immediately and are deleted in the background, so you do not have to tidy up. pruneExpiredSubscriptions exists for when the user asks what has lapsed, or asks you to clear things out.
 
 **Your Working Memory:**
 Use your working memory to track and recall:

--- a/mcp/mastra/verticals/synapse/state-change-batcher.ts
+++ b/mcp/mastra/verticals/synapse/state-change-batcher.ts
@@ -190,6 +190,17 @@ export class StateChangeBatcher {
    */
   private async matchSubscriptions(changes: PendingStateChange[]): Promise<string[]> {
     const storage = await getSubscriptionStorage();
+    // Housekeeping on the way past. Lapsed subscriptions are already filtered out of
+    // matching, so this only reclaims rows -- but a batch is the natural moment for it,
+    // and it is a single DELETE against a table with tens of rows.
+    const pruned = await storage.pruneExpired();
+    if (pruned.length > 0) {
+      logger.info('[BATCHER] Pruned lapsed subscriptions', {
+        count: pruned.length,
+        ids: pruned.map((subscription) => subscription.id),
+      });
+    }
+
     const subscriptions = await storage.getAllEmbedded();
 
     if (subscriptions.length === 0) {

--- a/mcp/mastra/verticals/synapse/subscription-expiry.spec.ts
+++ b/mcp/mastra/verticals/synapse/subscription-expiry.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Every subscription has to declare how it ends.
+ *
+ * Registration refuses one that does not, which is the part worth testing directly:
+ * the check runs before storage is touched, so these need no database and no model.
+ * The behaviour that follows from the fields — spending a budget, hiding a lapsed
+ * subscription, deleting it — is covered against a real database in
+ * `storage/subscriptions.spec.ts`.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { Subscription } from '../../storage/subscriptions.js';
+import { formatSubscriptionMatches, type SubscriptionMatch } from './subscription-matcher.js';
+import { registerSubscription, removeSubscription } from './subscription-tools.js';
+
+const BASE = {
+  whenEvent: 'the sun goes down',
+  thenAction: 'close the blinds',
+  source: 'synapse-expiry-spec',
+  oneShot: false,
+};
+
+describe('registerSubscription refusing an endless subscription', () => {
+  it('rejects a subscription with neither a budget nor a deadline', async () => {
+    // The cost of forgetting is invisible and cumulative — an endless subscription is
+    // scored against every state change forever and nothing ever removes it — so this
+    // fails loudly rather than quietly accepting one.
+    expect(registerSubscription.execute({ ...BASE })).rejects.toThrow(/needs an end/);
+  });
+
+  it('explains both ways of supplying one, so the model can retry', async () => {
+    expect(registerSubscription.execute({ ...BASE })).rejects.toThrow(/maxTriggerCount/);
+    expect(registerSubscription.execute({ ...BASE })).rejects.toThrow(/expiresAt/);
+  });
+
+  it('accepts oneShot, which supplies the budget implicitly', async () => {
+    // oneShot means "fire once", which is an end. Demanding maxTriggerCount as well
+    // would be asking the model to say the same thing twice.
+    const result = await registerSubscription.execute({ ...BASE, oneShot: true });
+
+    try {
+      expect(result.registered).toBe(true);
+      expect(result.subscription.maxTriggerCount).toBe(1);
+    } finally {
+      await removeSubscription.execute({ subscriptionId: result.subscription.id });
+    }
+  });
+
+  it('accepts a deadline on its own', async () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    const result = await registerSubscription.execute({ ...BASE, expiresAt });
+
+    try {
+      expect(result.subscription.expiresAt).toBe(expiresAt);
+      expect(result.subscription.maxTriggerCount).toBeNull();
+    } finally {
+      await removeSubscription.execute({ subscriptionId: result.subscription.id });
+    }
+  });
+
+  it('accepts a budget on its own, and keeps both when given both', async () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    const result = await registerSubscription.execute({ ...BASE, maxTriggerCount: 5, expiresAt });
+
+    try {
+      // Whichever comes first ends the subscription.
+      expect(result.subscription.maxTriggerCount).toBe(5);
+      expect(result.subscription.expiresAt).toBe(expiresAt);
+    } finally {
+      await removeSubscription.execute({ subscriptionId: result.subscription.id });
+    }
+  });
+});
+
+describe('showing the agent what is left of a subscription', () => {
+  function match(overrides: Partial<Subscription>): SubscriptionMatch {
+    const subscription: Subscription = {
+      id: 'subscription-1',
+      source: 'user',
+      whenEvent: 'the sun goes down',
+      thenAction: 'close the blinds',
+      oneShot: false,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      lastTriggeredAt: null,
+      triggerCount: 0,
+      maxTriggerCount: null,
+      expiresAt: null,
+      ...overrides,
+    };
+
+    return { subscription, whenScore: 0.62, givenScore: null, score: 0.62 };
+  }
+
+  it('reports how many firings remain', () => {
+    const formatted = formatSubscriptionMatches([match({ maxTriggerCount: 3, triggerCount: 1 })]);
+
+    // The agent can then weigh acting now against spending the last of a small budget
+    // on a marginal match.
+    expect(formatted).toContain('Firings left: 2 of 3');
+  });
+
+  it('never reports a negative number of firings', () => {
+    // A subscription is pruned once spent, but it can be formatted in the window
+    // between firing and pruning.
+    const formatted = formatSubscriptionMatches([match({ maxTriggerCount: 1, triggerCount: 4 })]);
+
+    expect(formatted).toContain('Firings left: 0 of 1');
+  });
+
+  it('reports the deadline', () => {
+    const expiresAt = '2026-09-01T00:00:00.000Z';
+    const formatted = formatSubscriptionMatches([match({ expiresAt })]);
+
+    expect(formatted).toContain(`Expires: ${expiresAt}`);
+  });
+
+  it('says nothing about limits a subscription does not have', () => {
+    const formatted = formatSubscriptionMatches([match({})]);
+
+    expect(formatted).not.toContain('Firings left');
+    expect(formatted).not.toContain('Expires');
+  });
+});

--- a/mcp/mastra/verticals/synapse/subscription-matcher.ts
+++ b/mcp/mastra/verticals/synapse/subscription-matcher.ts
@@ -167,6 +167,17 @@ export function formatSubscriptionMatches(matches: SubscriptionMatch[]): string 
         lines.push(`   Last triggered: ${subscription.lastTriggeredAt} (${subscription.triggerCount}x)`);
       }
 
+      // What is left of the subscription, so the agent can weigh acting now against
+      // spending the last of a limited budget on a marginal match.
+      if (subscription.maxTriggerCount !== null) {
+        const remaining = Math.max(0, subscription.maxTriggerCount - subscription.triggerCount);
+        lines.push(`   Firings left: ${remaining} of ${subscription.maxTriggerCount}`);
+      }
+
+      if (subscription.expiresAt) {
+        lines.push(`   Expires: ${subscription.expiresAt}`);
+      }
+
       return lines.join('\n');
     })
     .join('\n\n');

--- a/mcp/mastra/verticals/synapse/subscription-tools.ts
+++ b/mcp/mastra/verticals/synapse/subscription-tools.ts
@@ -20,6 +20,8 @@ const subscriptionSchema = z.object({
   createdAt: z.string(),
   lastTriggeredAt: z.string().nullable(),
   triggerCount: z.number(),
+  maxTriggerCount: z.number().nullable(),
+  expiresAt: z.string().nullable(),
 });
 
 /**
@@ -34,7 +36,7 @@ const subscriptionSchema = z.object({
 export const registerSubscription = createTool({
   id: 'registerSubscription',
   description:
-    'Registers a subscription (a point of interest) using a Given/When/Then structure. Use this whenever the user shows interest in something or asks for something to happen when something else happens. The WHEN is the triggering event, the GIVEN is an optional precondition, and the THEN is the action. Example: "When the sun goes down, if the lights are on, close the blinds."',
+    'Registers a subscription (a point of interest) using a Given/When/Then structure. Use this whenever the user shows interest in something or asks for something to happen when something else happens. The WHEN is the triggering event, the GIVEN is an optional precondition, and the THEN is the action. Example: "When the sun goes down, if the lights are on, close the blinds." You MUST give it an end: either maxTriggerCount (how many firings) or expiresAt (a date), or both. Nothing watches forever, and a subscription with no end quietly accumulates for the rest of the system\'s life.',
   inputSchema: z.object({
     whenEvent: z
       .string()
@@ -58,7 +60,21 @@ export const registerSubscription = createTool({
       .boolean()
       .default(false)
       .describe(
-        'True when the subscription should only ever fire once, e.g. "the NEXT time I get home from work". Defaults to false (recurring).',
+        'True when the subscription should only ever fire once, e.g. "the NEXT time I get home from work". Shorthand for maxTriggerCount: 1. Defaults to false (recurring).',
+      ),
+    maxTriggerCount: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'How many times this may fire before it is deleted. Use when the request has a natural count: "remind me for the next three deliveries" is 3. Omit for something open-ended like "whenever the doorbell rings", and give expiresAt instead.',
+      ),
+    expiresAt: z
+      .string()
+      .optional()
+      .describe(
+        'ISO 8601 timestamp after which this is deleted, e.g. "2026-09-01T00:00:00.000Z". Use for anything tied to a date ("until I get back from holiday on the 8th") and as the catch-all for open-ended requests, where a generous horizon such as six months is better than none.',
       ),
   }),
   outputSchema: z.object({
@@ -66,11 +82,25 @@ export const registerSubscription = createTool({
     subscription: subscriptionSchema,
   }),
   execute: async (inputData) => {
+    // Every subscription has to say how it ends. Enforced here rather than only in the
+    // schema description, because the cost of forgetting is invisible and cumulative:
+    // an endless subscription is scored against every state change forever, and nothing
+    // ever removes it. Throwing gives the model a specific thing to fix and retry.
+    const oneShot = inputData.oneShot ?? false;
+    const maxTriggerCount = inputData.maxTriggerCount ?? (oneShot ? 1 : null);
+
+    if (maxTriggerCount === null && !inputData.expiresAt) {
+      throw new Error(
+        'A subscription needs an end: pass maxTriggerCount (how many times it may fire), expiresAt (an ISO timestamp), or both. For an open-ended request, pick a generous expiresAt such as six months out rather than leaving it unbounded.',
+      );
+    }
+
     logger.info('Registering subscription', {
       whenEvent: inputData.whenEvent,
       givenCondition: inputData.givenCondition,
       thenAction: inputData.thenAction,
-      oneShot: inputData.oneShot,
+      maxTriggerCount,
+      expiresAt: inputData.expiresAt ?? null,
     });
 
     const [whenEmbedding, thenEmbedding, givenEmbedding] = await embedTexts([
@@ -90,7 +120,9 @@ export const registerSubscription = createTool({
         whenEvent: inputData.whenEvent,
         givenCondition: inputData.givenCondition,
         thenAction: inputData.thenAction,
-        oneShot: inputData.oneShot,
+        oneShot,
+        maxTriggerCount,
+        expiresAt: inputData.expiresAt ?? null,
       },
       {
         whenEvent: whenEmbedding,
@@ -265,6 +297,41 @@ export const setSubscriptionEnabled = createTool({
   },
 });
 
+/**
+ * Deletes the subscriptions that can no longer fire.
+ */
+export const pruneExpiredSubscriptions = createTool({
+  id: 'pruneExpiredSubscriptions',
+  description:
+    'Deletes subscriptions that have run out of firings or passed their expiry date. They are already ignored when matching, so this is housekeeping rather than something the user is waiting on. Use it when asked to tidy up, or to report what has lapsed.',
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    removed: z.array(subscriptionSchema),
+    count: z.number(),
+    message: z.string(),
+  }),
+  execute: async () => {
+    const storage = await getSubscriptionStorage();
+    const removed = await storage.pruneExpired();
+
+    if (removed.length > 0) {
+      logger.info('Pruned expired subscriptions', {
+        count: removed.length,
+        ids: removed.map((subscription) => subscription.id),
+      });
+    }
+
+    return {
+      removed,
+      count: removed.length,
+      message:
+        removed.length === 0
+          ? 'No subscriptions had lapsed'
+          : `Removed ${removed.length} lapsed subscription${removed.length === 1 ? '' : 's'}`,
+    };
+  },
+});
+
 export const subscriptionTools = {
   registerSubscription,
   listSubscriptions,
@@ -272,4 +339,5 @@ export const subscriptionTools = {
   markSubscriptionTriggered,
   removeSubscription,
   setSubscriptionEnabled,
+  pruneExpiredSubscriptions,
 };

--- a/mcp/mastra/verticals/synapse/tools.spec.ts
+++ b/mcp/mastra/verticals/synapse/tools.spec.ts
@@ -77,6 +77,8 @@ describe('Synapse Tools Integration Tests', () => {
         givenCondition: 'the lights are on',
         thenAction: 'close the blinds',
         source: 'synapse-tools-spec',
+        // oneShot is shorthand for maxTriggerCount: 1, which satisfies the requirement
+        // that every subscription declares how it ends.
         oneShot: true,
       });
 
@@ -123,6 +125,9 @@ describe('Synapse Tools Integration Tests', () => {
         thenAction: 'add milk to the shopping list',
         source: 'synapse-tools-spec',
         oneShot: false,
+        // Recurring, but not forever: registration insists on an end, so a subscription
+        // cannot be created that is scored against every state change indefinitely.
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
       });
 
       try {


### PR DESCRIPTION
Branched from `main`, independent of #671 and #672.

## Answering the question first

**No, there was no expiry.** `oneShot` retired a subscription after one firing, and `setEnabled` could pause one by hand — but nothing else ever removed anything. A subscription registered once was scored against every state change for the rest of the system's life, and the set only ever grew.

## Two ways to end one

Requests come in both shapes, so both are supported:

| Field | For | Example |
| --- | --- | --- |
| `maxTriggerCount` | a firing budget | *"remind me for the next three deliveries"* → 3 |
| `expiresAt` | a deadline | *"until I'm back from holiday on the 8th"* |

Set both and whichever comes first wins. `oneShot` is folded in as a budget of one, so there is a **single rule** for when a subscription is spent rather than two that can drift apart.

## Making the LLM always supply one

`registerSubscription` now **throws** when given neither:

```
A subscription needs an end: pass maxTriggerCount (how many times it may fire),
expiresAt (an ISO timestamp), or both. For an open-ended request, pick a generous
expiresAt such as six months out rather than leaving it unbounded.
```

Deliberately an error rather than a silent default. The cost of an endless subscription is invisible at the moment it is created and only shows up much later, as a slowly growing set nobody remembers agreeing to — so the model is made to answer the question. The message names both fields and suggests a fallback, which gives it something specific to retry with rather than a bare rejection.

The reactor's instructions now say the same, including the reasoning for open-ended requests: *an interest the user has forgotten about is usually one they no longer hold.*

## Pruning

A lapsed subscription **stops matching immediately** — reads filter on the deadline rather than waiting for a sweep — and is then deleted by a prune that runs on the way past in the batcher. There is also a `pruneExpiredSubscriptions` tool for when the user asks what has lapsed or asks you to tidy up.

Pruning deliberately spares anything disabled **by hand**. `setEnabled(id, false)` is a pause, and a pause should not quietly become a deletion; there is a test for that distinction.

## Better decisions at the prompt

Candidates now carry what is left of them into the reactor prompt:

```
   Firings left: 2 of 3
   Expires: 2026-09-01T00:00:00.000Z
```

Spending the last firing of a small budget on a marginal match is a real trade-off, and the agent could not previously see it.

## Migration

Two nullable columns behind a `PRAGMA table_info` guard, since SQLite has no `ADD COLUMN IF NOT EXISTS`. Existing rows read back as `null`, which every check treats as "no limit" — so they behave exactly as before and are **never pruned**. Only newly registered subscriptions are held to the rule.

## Tests

21 in `storage/subscriptions.spec.ts` covering budget spending, deadline filtering, and every prune case including the ones that must *not* be pruned; 9 in `subscription-expiry.spec.ts` covering the refusal, each accepted combination, and the prompt output.

One existing test needed updating — it registered a recurring subscription with no end, which is now exactly what the feature forbids. Fixed by giving it a deadline rather than by weakening the rule.

Full mcp suite: **256 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
