### PR TITLE
fix(routing): let the routing workflow start without a hand-written initial state

### DIFF
--- a/mcp/mastra/verticals/routing/workflows.ts
+++ b/mcp/mastra/verticals/routing/workflows.ts
@@ -57,9 +57,28 @@ const dagTaskSchema = outputTaskSchema.extend({
   reported: z.boolean().describe('Whether the task result has been reported back to Jarvis'),
 });
 
+/**
+ * The routing DAG, which is also the workflow's state.
+ *
+ * Both fields default to empty because the state has to validate *before* the
+ * workflow starts, and at that point nothing has been planned yet — `plan-tasks`
+ * is what fills it in, on the first step. Without the defaults, starting a run
+ * meant hand-writing an initial state that the first step immediately threw away:
+ *
+ *   Invalid initial data:
+ *   - userQuery: expected string, received undefined
+ *   - tasks: expected array, received undefined
+ *
+ * which made the workflow effectively impossible to try from Mastra Studio, where
+ * you would have to know the shape of a state you are not supposed to supply.
+ *
+ * An empty DAG is also the honest representation of "no plan yet", so the steps
+ * that read state before planning now see an empty task list rather than failing
+ * validation.
+ */
 export const dagSchema = z.object({
-  userQuery: z.string().describe('The user query the DAG was planned for'),
-  tasks: z.array(dagTaskSchema),
+  userQuery: z.string().default('').describe('The user query the DAG was planned for'),
+  tasks: z.array(dagTaskSchema).default([]),
 });
 
 export type Dag = z.infer<typeof dagSchema>;


### PR DESCRIPTION
Follow-up to verifying the routing agent in Mastra Studio, where the first thing I hit was that **you cannot start this workflow from the UI at all**.

## The problem

Press Run with the form untouched:

```
Invalid initial data:
- userQuery: expected string, received undefined
- tasks: expected array, received undefined
```

The state schema *is* the DAG, and Mastra validates state before the first step runs — but the DAG is what the first step produces. So trying the workflow by hand meant hand-writing an initial state that `plan-tasks` immediately overwrites with `setState`, after working out its shape from the source:

```json
{"inputData": {"userQuery": "..."},
 "initialState": {"userQuery": "...", "tasks": []}}
```

None of that is discoverable from the UI, and "Invalid initial data" gives no hint that it means something you are not supposed to supply.

## The fix

```ts
export const dagSchema = z.object({
  userQuery: z.string().default('').describe('The user query the DAG was planned for'),
  tasks: z.array(dagTaskSchema).default([]),
});
```

An empty DAG is also the honest representation of "nothing planned yet", so a step that reads state before planning now sees an empty task list rather than failing validation. The inferred **output** type is unchanged, so nothing downstream has to know about it.

`userQuery` already carried a default query, so with the state requirement gone the whole form can be left alone.

## Verified end to end

One click on Run, form untouched:

1. `plan-tasks` turns the default query into a **five-task DAG** — weather, calendar, lasagne recipe, commute traffic, todo reminder
2. Suspends at `hand-off-to-caller` — *"Step suspended / Needs input"*
3. Resume → a wave executes (11.9s)
4. Suspends again at `routingWaveWorkflow.report-progress` with 4.2 KB of wave results for the caller to relay
5. Resume → second wave → `finalize-routing`
6. **Success, 2m 9s**, every step green

Also confirmed through the API that `{"inputData":{}}` now starts a run — no `initialState`, no `userQuery`.

Full mcp suite: **256 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
