### PR TITLE
fix(mcp): close the email approval loop, surface real workflow errors, typecheck the tests

### DIFF
--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -527,10 +527,10 @@ export function initializeScheduler(): WorkflowScheduler {
 └───────── Minute (0-59)
 ```
 
-**Currently Scheduled Workflows:**
-1. **Weather Monitoring** - Runs every hour at minute 0
+**Currently Scheduled Workflows** (see `mastra/scheduler.ts`):
+1. **Weather Monitoring** - Runs every 3 hours
    - Workflow: `weatherMonitoringWorkflow`
-   - Schedule: `0 * * * *`
+   - Schedule: `0 */3 * * *`
    - Purpose: Updates weather information and notifies other agents of changes
 
 2. **Weekly Meal Planning** - Runs every Sunday at 8:00 AM
@@ -538,15 +538,22 @@ export function initializeScheduler(): WorkflowScheduler {
    - Schedule: `0 8 * * 0`
    - Purpose: Generates weekly meal plan with Danish recipes
 
-3. **Check for New Emails** - Runs every 30 minutes + on startup
-   - Workflow: `checkForNewEmails`
-   - Schedule: `*/30 * * * *`
+3. **Email Checking** - Runs every minute + on startup
+   - Workflow: `emailCheckingWorkflow`
+   - Schedule: `* * * * *`
    - Run on startup: **Yes**
-   - Purpose: Checks for new emails and processes form replies
+   - Purpose: Tracks which emails have arrived; does not trigger the state reactor
 
-4. **IoT Device Monitoring** - Runs every 5 minutes + on startup
+4. **Form Replies Detection** - Runs every 3 hours + on startup
+   - Workflow: `formRepliesDetectionWorkflow`
+   - Schedule: `0 */3 * * *`
+   - Run on startup: **Yes**
+   - Purpose: Resumes the suspended runs that inbound form replies answer, and registers the
+     emails as a state change
+
+5. **IoT Device Monitoring** - Runs every 3 hours + on startup
    - Workflow: `iotMonitoringWorkflow`
-   - Schedule: `*/5 * * * *`
+   - Schedule: `0 */3 * * *`
    - Run on startup: **Yes**
    - Purpose: Monitors Home Assistant devices and registers state changes
 
@@ -766,29 +773,37 @@ Demonstrates email-based workflow suspension and resumption with a 3-step approv
 - **Step 1 - Budget Approval**: Requests approval for project budget (Yes/No + comments)
 - **Step 2 - Vendor Selection**: Requests vendor selection (Vendor name + justification)
 - **Step 3 - Final Confirmation**: Requests final action confirmation (Confirm/Cancel + notes)
-- **Email integration**: Sends form request emails with embedded workflow IDs
-- **Security validation**: Validates sender email and workflow ID before resuming
-- **LLM parsing**: Uses Gemini to extract structured data from email responses
-- **14-day timeout**: Each suspend step times out after 14 days by default
+- **Email integration**: Sends form request emails carrying the id of the suspended run
+- **Security validation**: Only a reply from the address that was asked is accepted
+- **LLM parsing**: `parseEmailReply()` turns the free text of the reply into the typed response
+- **No timeout**: A suspended request waits until it is answered — nothing expires it, and the
+  email does not claim otherwise
 
 **Email Format:**
-- Subject: `Form Request [WF-{workflowId}]: {question}`
-- Body: Question + instructions + workflow ID + expiry date
-- Resume trigger: Reply email with matching workflow ID in subject
+- Subject: `Form Request [RUN-{runId}/REQ-{requestId}]: {question}`
+- Body: Question + instructions + the request reference (`{runId}/{requestId}`)
+- Resume trigger: A reply whose subject still carries both ids
 
 **Workflow Steps:**
-1. **Initialize**: Store recipient email in workflow state
+1. **Initialize**: Pass the recipient, project name and budget through
 2. **Request Budget Approval**: Send email, suspend workflow, wait for reply
-3. **Check Approval**: Validate response and decide if workflow continues
-4. **Request Vendor Selection**: If approved, send email, suspend, wait for reply
+3. **Stop When Budget Is Rejected**: A "no" finishes the run with `approvalGranted: false`
+4. **Request Vendor Selection**: Send email, suspend, wait for reply
 5. **Request Final Confirmation**: Send email, suspend, wait for reply
 6. **Format Output**: Generate final result with all collected data
 
 **Security Features:**
-- Workflow ID embedded in email subject: `[WF-{id}]`
-- Sender email validation against expected recipient
-- Workflow state stores expected reply email
-- 14-day timeout prevents indefinite suspension
+- Run id embedded in the email subject: `[RUN-{runId}/...]` — unlike a workflow id, which is
+  shared by every run and every recipient
+- Request id alongside it: `[.../REQ-{requestId}]`, minted per question. Every stage of one run
+  suspends under the same run id, so the request id is what says *which* question a reply
+  answers; a reply is only accepted for the request the run is still waiting on
+- Sender validated against the address the request was sent to; an empty sender is refused
+  rather than skipped
+- A reply that fails validation is refused and the request stays open, so a wrong-sender,
+  duplicate or late reply cannot destroy a pending approval or answer the wrong question
+- An empty reply body is refused rather than handed to the parsing agent
+- `recipientEmail` is required: there is no default address a stray Studio run could mail
 
 **Usage Example:**
 ```typescript
@@ -803,23 +818,23 @@ const result = await run.start({
 
 // Workflow suspends and sends email
 // User replies to email with answer
-// checkForFormRepliesWorkflow (runs every 5 minutes) detects reply and resumes workflow
+// formRepliesDetectionWorkflow (runs every 3 hours) finds the reply and resumes the run
 ```
 
 **Helper Functions:**
-- `sendFormRequest()`: Sends email with workflow ID and suspends workflow
-- `parseEmailResponse()`: Uses LLM to extract structured data from email body
+- `getSendEmailAndAwaitResponseWorkflow(slug, responseSchema)`: Reusable send-and-wait workflow,
+  embeddable in any parent workflow with `.then(...)`
+- `parseEmailReply()`: Uses the email parsing agent to extract the typed answer from a reply
 
-### Check for New Emails Workflow
-Parent workflow that orchestrates email discovery, form reply processing, and state change registration with **persistent tracking** of the last seen email:
-- **`checkForNewEmails`**: Scheduled workflow that runs every 30 minutes + on startup
-- **Step 1 - Search NEW Emails**: Uses `findNewEmailsSinceLastCheck` function with persistent storage to fetch only emails received since the last workflow run
+### Email Checking Workflow
+Tracks which emails have arrived, with **persistent tracking** of the last seen email. It does
+not touch form replies or the state reactor — that is the form replies workflow below, which
+keeps its own last-seen state under a separate storage key:
+- **`emailCheckingWorkflow`**: Scheduled workflow that runs every minute + on startup
+- **Step 1 - Search NEW Emails**: Uses `findNewEmailsSinceLastCheck` with persistent storage to fetch only emails received since the last workflow run
 - **Step 2 - Store in State**: Stores new emails in workflow state and tracks the most recent email ID/timestamp
-- **Step 3 - Parallel Processing**:
-  - Process form replies (delegates to checkForFormRepliesWorkflow)
-  - Register state changes for notification system
-- **Step 4 - Update Last Seen**: Updates the `email_last_seen` database table with the most recent email
-- **Step 5 - Format Output**: Returns summary with email count and update status
+- **Step 3 - Update Last Seen**: Updates the `email_last_seen` database table with the most recent email
+- **Step 4 - Format Output**: Returns summary with email count and update status
 
 **Key Feature - Persistent Email Tracking:**
 The workflow uses the `email_last_seen` database table to track which emails have been processed:
@@ -831,8 +846,8 @@ The workflow uses the `email_last_seen` database table to track which emails hav
 **Email State Functions:**
 These are internal functions (not exposed as agent tools) for tracking email state:
 ```typescript
-// Find only NEW emails since last check (used by workflow)
-const result = await findNewEmailsSinceLastCheck('inbox', 50);
+// Find only NEW emails since last check (storage key, mailbox folder, limit)
+const result = await findNewEmailsSinceLastCheck('inbox', 'inbox', 50);
 
 // Manually update last seen state
 await updateLastSeenEmail('inbox', 'email-id-123', '2025-12-01T10:00:00Z');
@@ -847,61 +862,48 @@ await clearLastSeenEmailState('inbox');
 **Scheduled Execution:**
 ```typescript
 scheduler.schedule({
-  workflow: checkForNewEmails,
-  schedule: CronPatterns.EVERY_30_MINUTES,
+  workflow: emailCheckingWorkflow,
+  schedule: CronPatterns.EVERY_MINUTE,
   inputData: {},
   runOnStartup: true,
 });
 ```
 
-### Email Checking Workflow
-Automatically processes incoming email replies to form requests and resumes suspended workflows:
-- **`checkForFormRepliesWorkflow`**: Scheduled workflow that runs every 5 minutes
-- **Step 1 - Search**: Searches inbox for unread emails
-- **Step 2 - Extract**: Extracts workflow IDs from email subjects using regex `[WF-{id}]`
-- **Step 3 - Process**: For each email with workflow ID:
-  - Gets workflow run by ID
-  - Parses email body using LLM
-  - Resumes workflow with parsed data
-  - Registers state change for tracking
-- **Step 4 - Summary**: Returns count of processed emails and resumed workflows
+### Form Replies Detection Workflow
+Automatically processes incoming email replies to form requests and resumes the suspended runs
+they answer:
+- **`formRepliesDetectionWorkflow`**: Scheduled workflow that runs every 3 hours
+- **Step 1 - Search**: Finds emails received since this workflow's own last check
+  (storage key `inbox-form-replies`)
+- **Step 2 - Extract**: Reads the run id and request id out of the subject with
+  `parseFormRequestSubject()` — the same function that builds the subject writes it, so the two
+  sides cannot drift apart
+- **Step 3 - Process**: For each email carrying the token:
+  - Finds the run by asking each registered workflow whether it holds it
+  - Hands the reply to the step that suspended, which checks the request id and the sender, and
+    parses the free text with the email parsing agent
+  - Counts the reply as resumed, rejected, or (no such run) an error
+- **Step 4 - Register**: Registers the emails as a state change for the notification system
+- **Step 5 - Summary**: Returns counts of emails processed, replies found, runs resumed and
+  replies rejected
 
 **Scheduled Execution:**
 ```typescript
 scheduler.schedule({
-  workflowId: 'checkForFormRepliesWorkflow',
-  schedule: CronPatterns.EVERY_5_MINUTES,
+  workflow: formRepliesDetectionWorkflow,
+  schedule: CronPatterns.EVERY_3_HOURS,
   inputData: {},
+  runOnStartup: true,
 });
 ```
 
-**State Change Registration:**
-When a form reply is successfully processed, registers a state change:
-```typescript
-await registerStateChange.execute({
-  source: 'email',
-  stateType: 'form_reply_processed',
-  stateData: {
-    workflowId,
-    senderEmail: email.from.address,
-    emailSubject: email.subject,
-    receivedDateTime: email.receivedDateTime,
-  },
-});
-```
-
-**Current Limitations:**
-- Workflow run retrieval not yet implemented (requires Mastra enhancement)
-- Uses email body preview instead of full body
-- Only supports `humanInTheLoopDemoWorkflow` (hardcoded workflow type)
-- Manual workflow resume implementation needed
-
-**Future Enhancements:**
-- Support multiple workflow types
-- Fetch full email body for better parsing
-- Implement workflow run registry for pending workflows
-- Add workflow type detection from email metadata
-- Support email threading for multi-turn conversations
+**When a reply is refused:**
+A refused reply leaves the run suspended exactly where it was, so the person who was asked can
+still answer. Replies are refused when they come from an address other than the one the request
+was sent to, when they answer a request the run has already moved past, when the body is blank,
+and when the parsing agent cannot read an answer out of them. Each is counted in
+`repliesRejected` rather than reported as an error, because nothing has gone wrong with the
+system. Only a token naming a run that does not exist is reported as an error.
 
 ## Processors
 

--- a/mcp/mastra/cors.spec.ts
+++ b/mcp/mastra/cors.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'bun:test';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { getAllowedOrigins, getCorsOptions } from './cors.js';

--- a/mcp/mastra/utils/errors.spec.ts
+++ b/mcp/mastra/utils/errors.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { extractErrorMessage } from './errors.js';
+
+const FAILURE_MESSAGE = 'the fridge is on fire';
+
+/**
+ * Every shape an error slot has been observed to hold. The API layer and the email reply
+ * handler both read errors that Mastra has already serialised, which is why a plain
+ * object and a bare string matter as much as a real `Error`.
+ */
+describe('extractErrorMessage', () => {
+  it('reads an Error instance', () => {
+    expect(extractErrorMessage(new Error(FAILURE_MESSAGE))).toBe(FAILURE_MESSAGE);
+  });
+
+  it('reads the plain object Mastra serialises an error into', () => {
+    expect(extractErrorMessage({ message: FAILURE_MESSAGE, name: 'Error' })).toBe(FAILURE_MESSAGE);
+  });
+
+  it('reads a bare string', () => {
+    expect(extractErrorMessage(FAILURE_MESSAGE)).toBe(FAILURE_MESSAGE);
+  });
+
+  it('reports nothing when there is no error at all', () => {
+    expect(extractErrorMessage(undefined)).toBeUndefined();
+    expect(extractErrorMessage(null)).toBeUndefined();
+  });
+
+  it('reports nothing for an object carrying no message', () => {
+    expect(extractErrorMessage({ name: 'Error' })).toBeUndefined();
+  });
+
+  it('reports nothing for a message that is not a string', () => {
+    // Reading `.message` straight off the object would hand a caller `[object Object]`.
+    expect(extractErrorMessage({ message: { nested: 'detail' } })).toBeUndefined();
+  });
+
+  it('treats an empty message as no detail', () => {
+    // A blank `error` field reads as "no reason given"; the caller's fallback says more.
+    expect(extractErrorMessage('')).toBeUndefined();
+    expect(extractErrorMessage({ message: '' })).toBeUndefined();
+  });
+});

--- a/mcp/mastra/utils/errors.ts
+++ b/mcp/mastra/utils/errors.ts
@@ -1,0 +1,32 @@
+/**
+ * Reads the human-readable message out of whatever ended up in an error slot.
+ *
+ * The parameter is `unknown` because Mastra's declared type is not what turns up at
+ * runtime: the engine serialises the error with `Error.prototype.toJSON` before
+ * returning a workflow result, so a failed run carries a plain `{ message, name }`
+ * object rather than an `Error`. Runs that never reached the engine still carry a real
+ * `Error`, and a message that came back over the wire can be a bare string.
+ *
+ * Lives in `utils` rather than in one vertical because both the API layer and the email
+ * reply handler read errors that have been through that serialisation.
+ *
+ * @returns The message, or `undefined` when there is no detail to report.
+ */
+export function extractErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.message || undefined;
+  }
+
+  if (typeof error === 'string') {
+    return error || undefined;
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const { message } = error;
+    if (typeof message === 'string' && message !== '') {
+      return message;
+    }
+  }
+
+  return undefined;
+}

--- a/mcp/mastra/utils/tool-factory.spec.ts
+++ b/mcp/mastra/utils/tool-factory.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'bun:test';
 import type { ToolExecuteContext, ToolExecutionContext } from '@mastra/core/tools';
 import { createToolExecutionContext, executeTool } from './tool-factory.js';
 

--- a/mcp/mastra/utils/workflows/workflow-factory.ts
+++ b/mcp/mastra/utils/workflows/workflow-factory.ts
@@ -14,6 +14,20 @@ import { createAgent } from '../agent-factory.js';
 import { executeTool } from '../tool-factory.js';
 
 /**
+ * One suspended step as {@link createWorkflowStateReader} reports it: the id, the path to
+ * resume it by, and the payload it suspended with.
+ */
+export type { WorkflowSuspendedStep } from '@mastra/core/workflows';
+/**
+ * Reads a persisted workflow run snapshot without touching its raw shape.
+ *
+ * Re-exported so callers that recover a suspended run from storage — locating the step to
+ * resume and the payload it suspended with — keep importing workflow plumbing from this
+ * factory rather than from `@mastra/core` directly.
+ */
+export { createWorkflowStateReader } from '@mastra/core/workflows';
+
+/**
  * A Workflow with all generic parameters set to their defaults.
  * Used when accepting any workflow instance without caring about specific types.
  */

--- a/mcp/mastra/verticals/api/routes.spec.ts
+++ b/mcp/mastra/verticals/api/routes.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * On a failed run the API layer's only job is to tell the caller why it failed.
+ *
+ * Mastra serialises the error before the result leaves the engine, so the field the
+ * handler reads holds a plain object rather than the `Error` its type promises. The
+ * shapes `extractErrorMessage` has to understand are pinned next to it in
+ * `utils/errors.spec.ts`; these tests pin what a real failing run actually produces.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
+import { createStep, createWorkflow, getWorkflowRuntime } from '../../utils/workflows/workflow-factory.js';
+import { extractWorkflowError } from './routes.js';
+
+const FAILURE_MESSAGE = 'the fridge is on fire';
+
+const failingStep = createStep({
+  id: 'always-fails',
+  description: 'Throws, so the run ends in the failed state.',
+  inputSchema: z.object({}),
+  outputSchema: z.object({}),
+  execute: async () => {
+    throw new Error(FAILURE_MESSAGE);
+  },
+});
+
+const failingWorkflow = createWorkflow({
+  id: 'failingWorkflow',
+  inputSchema: z.object({}),
+  outputSchema: z.object({}),
+})
+  .then(failingStep)
+  .commit();
+
+async function runFailingWorkflow() {
+  const run = await failingWorkflow.createRun();
+  return await run.start({ inputData: {} });
+}
+
+const suspendingStep = createStep({
+  id: 'always-suspends',
+  description: 'Suspends, so the run ends without an error to report.',
+  inputSchema: z.object({}),
+  outputSchema: z.object({}),
+  suspendSchema: z.object({}),
+  execute: async ({ suspend }) => await suspend({}),
+});
+
+// Suspending persists a run snapshot, which needs a Mastra instance to persist through.
+const suspendingWorkflow = createWorkflow({
+  id: 'suspendingWorkflow',
+  mastra: getWorkflowRuntime(),
+  inputSchema: z.object({}),
+  outputSchema: z.object({}),
+})
+  .then(suspendingStep)
+  .commit();
+
+describe('extractWorkflowError', () => {
+  it('surfaces the step failure from a real failed run', async () => {
+    const result = await runFailingWorkflow();
+
+    expect(result.status).toBe('failed');
+    expect(extractWorkflowError(result)).toBe(FAILURE_MESSAGE);
+  });
+
+  it('gets a plain object rather than an Error, which is why the naive check lost the message', async () => {
+    const result = await runFailingWorkflow();
+
+    if (result.status !== 'failed') {
+      throw new Error(`Expected the run to fail, but it reported ${result.status}.`);
+    }
+
+    // Mastra's types promise an `Error` here, but `toJSON` has already run by the time
+    // the result reaches us, so an `instanceof Error` check finds nothing to report.
+    expect(result.error).not.toBeInstanceOf(Error);
+    expect(result.error).toMatchObject({ message: FAILURE_MESSAGE, name: 'Error' });
+  });
+
+  it('falls back to the status when the result carries no error at all', async () => {
+    // A suspended run is the everyday non-success result with nothing to explain.
+    const run = await suspendingWorkflow.createRun();
+    const result = await run.start({ inputData: {} });
+
+    expect(result.status).toBe('suspended');
+    expect(extractWorkflowError(result)).toBe('Workflow failed with status suspended');
+  });
+});

--- a/mcp/mastra/verticals/api/routes.ts
+++ b/mcp/mastra/verticals/api/routes.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response, Router } from 'express';
 import type { ZodTypeAny } from 'zod';
+import { extractErrorMessage } from '../../utils/errors.js';
 import { logger } from '../../utils/logger.js';
 import type { AnyWorkflow, AnyWorkflowResult } from '../../utils/workflows/workflow-factory.js';
 import { shoppingListWorkflow } from '../shopping/workflows.js';
@@ -24,13 +25,12 @@ function formatValidationErrors(zodError: {
 }
 
 /**
- * Extracts an error message from a workflow result.
+ * Extracts an error message from a workflow result, falling back to the status
+ * when the result carries no detail at all.
  */
-function extractWorkflowError(result: AnyWorkflowResult): string {
-  if ('error' in result && result.error instanceof Error) {
-    return result.error.message;
-  }
-  return `Workflow failed with status ${result.status}`;
+export function extractWorkflowError(result: AnyWorkflowResult): string {
+  const error: unknown = 'error' in result ? result.error : undefined;
+  return extractErrorMessage(error) ?? `Workflow failed with status ${result.status}`;
 }
 
 /**
@@ -69,7 +69,7 @@ export function createWorkflowApiHandler(
           }
         }
 
-        console.log(`[API] ${workflowName} request received`);
+        logger.info('[API] Request received', { workflowName });
 
         const run = await workflow.createRun();
         const result = await run.start({

--- a/mcp/mastra/verticals/calendar/tools.spec.ts
+++ b/mcp/mastra/verticals/calendar/tools.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { getAllCalendars, getCalendarEvents } from './tools';
 
 describe('Calendar Tools Integration Tests', () => {
@@ -17,7 +18,7 @@ describe('Calendar Tools Integration Tests', () => {
 
   describe('getAllCalendars', () => {
     it('should retrieve all calendars', async () => {
-      const result = await getAllCalendars.execute({});
+      const result = await executeTool(getAllCalendars, {});
 
       // Validate structure
       expect(result).toBeDefined();
@@ -30,7 +31,7 @@ describe('Calendar Tools Integration Tests', () => {
 
   describe('getCalendarEvents', () => {
     it('should retrieve calendar events', async () => {
-      const result = await getCalendarEvents.execute({
+      const result = await executeTool(getCalendarEvents, {
         calendarId: 'primary',
         maxResults: 5,
       });

--- a/mcp/mastra/verticals/coding/session-watcher.spec.ts
+++ b/mcp/mastra/verticals/coding/session-watcher.spec.ts
@@ -24,7 +24,7 @@ function runningEvent(id: string): ReportedSessionEvent {
 }
 
 function thinkingEvent(id: string): ClaudeSessionEvent {
-  return { id, type: 'agent.thinking', processed_at: PROCESSED_AT, thinking: 'hmm', signature: 'sig' };
+  return { id, type: 'agent.thinking', processed_at: PROCESSED_AT };
 }
 
 /** Waits for the watcher's detached event loop to drain. */
@@ -116,7 +116,6 @@ describe('isReportableEvent', () => {
         id: 'e',
         type: 'span.model_request_start',
         processed_at: PROCESSED_AT,
-        thread_id: 'thread_1',
       }),
     ).toBe(false);
   });

--- a/mcp/mastra/verticals/coding/tools.spec.ts
+++ b/mcp/mastra/verticals/coding/tools.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { listUserRepositories, searchRepositories } from './tools';
 
 describe('Coding Tools Integration Tests', () => {
@@ -13,7 +14,7 @@ describe('Coding Tools Integration Tests', () => {
 
   describe('searchRepositories', () => {
     it('should search for repositories on GitHub', async () => {
-      const result = await searchRepositories.execute({
+      const result = await executeTool(searchRepositories, {
         query: 'typescript language:typescript',
         maxResults: 5,
       });
@@ -38,9 +39,8 @@ describe('Coding Tools Integration Tests', () => {
 
   describe('listUserRepositories', () => {
     it('should list user repositories', async () => {
-      const result = await listUserRepositories.execute({
-        maxResults: 5,
-      });
+      // The tool takes only an optional username; it always returns the full list.
+      const result = await executeTool(listUserRepositories, {});
 
       // Validate structure
       expect(result).toBeDefined();

--- a/mcp/mastra/verticals/commute/tools.spec.ts
+++ b/mcp/mastra/verticals/commute/tools.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { commuteTools } from './tools';
 
 /**
@@ -55,15 +56,12 @@ describe('Commute Tools Integration Tests', () => {
 
   describe('getTravelTime', () => {
     it('should fetch travel time between two cities', async () => {
-      const result = await commuteTools.getTravelTime.execute!(
-        {
-          origin: 'Aarhus, Denmark',
-          destination: 'Copenhagen, Denmark',
-          mode: 'driving',
-          includeTraffic: true,
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.getTravelTime, {
+        origin: 'Aarhus, Denmark',
+        destination: 'Copenhagen, Denmark',
+        mode: 'driving',
+        includeTraffic: true,
+      });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -94,15 +92,12 @@ describe('Commute Tools Integration Tests', () => {
 
     it('should handle coordinates as input', async () => {
       // Coordinates for Aarhus and Copenhagen
-      const result = await commuteTools.getTravelTime.execute!(
-        {
-          origin: '56.1629,10.2039',
-          destination: '55.6761,12.5683',
-          mode: 'driving',
-          includeTraffic: false,
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.getTravelTime, {
+        origin: '56.1629,10.2039',
+        destination: '55.6761,12.5683',
+        mode: 'driving',
+        includeTraffic: false,
+      });
 
       expect(result).toBeDefined();
       expect(result.distance.value).toBeGreaterThan(150000);
@@ -110,15 +105,12 @@ describe('Commute Tools Integration Tests', () => {
     }, 30000);
 
     it('should support different travel modes', async () => {
-      const result = await commuteTools.getTravelTime.execute!(
-        {
-          origin: 'Aarhus, Denmark',
-          destination: 'Aarhus C, Denmark',
-          mode: 'walking',
-          includeTraffic: false,
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.getTravelTime, {
+        origin: 'Aarhus, Denmark',
+        destination: 'Aarhus C, Denmark',
+        mode: 'walking',
+        includeTraffic: false,
+      });
 
       expect(result).toBeDefined();
       expect(result.mode).toBe('walking');
@@ -128,15 +120,12 @@ describe('Commute Tools Integration Tests', () => {
 
   describe('searchPlacesAlongRoute', () => {
     it('should find EV charging stations along a route', async () => {
-      const result = await commuteTools.searchPlacesAlongRoute.execute!(
-        {
-          origin: 'Aarhus, Denmark',
-          destination: 'Copenhagen, Denmark',
-          searchQuery: 'EV charging station',
-          maxResults: 5,
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.searchPlacesAlongRoute, {
+        origin: 'Aarhus, Denmark',
+        destination: 'Copenhagen, Denmark',
+        searchQuery: 'EV charging station',
+        maxResults: 5,
+      });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -163,15 +152,12 @@ describe('Commute Tools Integration Tests', () => {
     }, 45000); // Longer timeout as this makes multiple API calls
 
     it('should find restaurants along a route', async () => {
-      const result = await commuteTools.searchPlacesAlongRoute.execute!(
-        {
-          origin: 'Aarhus, Denmark',
-          destination: 'Odense, Denmark',
-          searchQuery: 'restaurant',
-          maxResults: 3,
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.searchPlacesAlongRoute, {
+        origin: 'Aarhus, Denmark',
+        destination: 'Odense, Denmark',
+        searchQuery: 'restaurant',
+        maxResults: 3,
+      });
 
       expect(result).toBeDefined();
       expect(result.places.length).toBeGreaterThan(0);
@@ -184,15 +170,12 @@ describe('Commute Tools Integration Tests', () => {
 
   describe('searchPlacesByDistance', () => {
     it('should find nearby gas stations ordered by distance', async () => {
-      const result = await commuteTools.searchPlacesByDistance.execute!(
-        {
-          location: 'Aarhus, Denmark',
-          searchQuery: 'gas station',
-          radius: 5000,
-          maxResults: 5,
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.searchPlacesByDistance, {
+        location: 'Aarhus, Denmark',
+        searchQuery: 'gas station',
+        radius: 5000,
+        maxResults: 5,
+      });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -226,15 +209,12 @@ describe('Commute Tools Integration Tests', () => {
     }, 30000);
 
     it('should find coffee shops with larger radius', async () => {
-      const result = await commuteTools.searchPlacesByDistance.execute!(
-        {
-          location: 'Aarhus C, Denmark',
-          searchQuery: 'coffee shop',
-          radius: 2000,
-          maxResults: 10,
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.searchPlacesByDistance, {
+        location: 'Aarhus C, Denmark',
+        searchQuery: 'coffee shop',
+        radius: 2000,
+        maxResults: 10,
+      });
 
       expect(result).toBeDefined();
       expect(result.places.length).toBeGreaterThan(0);
@@ -247,13 +227,10 @@ describe('Commute Tools Integration Tests', () => {
 
   describe('getPlaceDetails', () => {
     it('should fetch details for a specific place by name', async () => {
-      const result = await commuteTools.getPlaceDetails.execute!(
-        {
-          placeName: 'Aros Aarhus Kunstmuseum',
-          location: 'Aarhus, Denmark',
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.getPlaceDetails, {
+        placeName: 'Aros Aarhus Kunstmuseum',
+        location: 'Aarhus, Denmark',
+      });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -282,13 +259,10 @@ describe('Commute Tools Integration Tests', () => {
     }, 30000);
 
     it('should include reviews when available', async () => {
-      const result = await commuteTools.getPlaceDetails.execute!(
-        {
-          placeName: 'Aarhus Domkirke',
-          location: 'Aarhus, Denmark',
-        },
-        {},
-      );
+      const result = await executeTool(commuteTools.getPlaceDetails, {
+        placeName: 'Aarhus Domkirke',
+        location: 'Aarhus, Denmark',
+      });
 
       expect(result).toBeDefined();
       expect(typeof result.name).toBe('string');

--- a/mcp/mastra/verticals/cooking/tools.spec.ts
+++ b/mcp/mastra/verticals/cooking/tools.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { cookingTools } from './tools';
 
 interface RecipeShape {
@@ -91,7 +92,7 @@ describe('Cooking Tools Integration Tests', () => {
   describe('getRecipeById', () => {
     it('should fetch a recipe by ID and validate schema', async () => {
       // Using a known recipe ID from Valdemarsro
-      const result = await cookingTools.getRecipeById.execute({ recipeId: '51796' });
+      const result = await executeTool(cookingTools.getRecipeById, { recipeId: '51796' });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -106,7 +107,7 @@ describe('Cooking Tools Integration Tests', () => {
 
   describe('searchRecipes', () => {
     it('should search for recipes and validate schema', async () => {
-      const result = await cookingTools.searchRecipes.execute({ searchTerm: 'kylling' });
+      const result = await executeTool(cookingTools.searchRecipes, { searchTerm: 'kylling' });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -133,7 +134,7 @@ describe('Cooking Tools Integration Tests', () => {
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
       const fromDate = thirtyDaysAgo.toISOString().split('T')[0];
 
-      const result = await cookingTools.getAllRecipes.execute({ fromDate });
+      const result = await executeTool(cookingTools.getAllRecipes, { fromDate });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -171,14 +172,20 @@ describe('Cooking Tools Integration Tests', () => {
 
   describe('getSearchFilters', () => {
     it('should fetch search filters', async () => {
-      const result = await cookingTools.getSearchFilters.execute({});
+      const result = await executeTool(cookingTools.getSearchFilters, {});
 
       // Validate structure
       expect(result).toBeDefined();
       expect(result.filters).toBeDefined();
 
+      // The tool's `filters` output has no declared shape, so narrow before reading its keys.
+      const { filters } = result;
+      if (typeof filters !== 'object' || filters === null) {
+        throw new Error(`Expected search filters to be an object, got ${typeof filters}`);
+      }
+
       console.log('✅ Search filters fetched successfully');
-      console.log('   Available filters:', Object.keys(result.filters));
+      console.log('   Available filters:', Object.keys(filters));
     }, 30000);
   });
 });

--- a/mcp/mastra/verticals/email/tools.spec.ts
+++ b/mcp/mastra/verticals/email/tools.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
-import { findEmails } from './tools';
+import { executeTool } from '../../utils/tool-factory.js';
+import { findEmails } from './tools.js';
 
 describe('Email Tools Integration Tests', () => {
   beforeAll(() => {
@@ -17,9 +18,9 @@ describe('Email Tools Integration Tests', () => {
 
   describe('findEmails', () => {
     it('should retrieve emails', async () => {
-      const result = await findEmails.execute({
-        maxResults: 5,
-      });
+      // `limit`, not `maxResults`. The old spelling was not a parameter of this tool at
+      // all, so it was silently dropped and the tool returned its default page instead.
+      const result = await executeTool(findEmails, { limit: 5, folder: 'inbox' });
 
       // Validate structure
       expect(result).toBeDefined();
@@ -31,17 +32,22 @@ describe('Email Tools Integration Tests', () => {
       // This is sensitive private information
     }, 30000);
 
-    it('should support filtering by sender', async () => {
-      const result = await findEmails.execute({
-        from: 'noreply@example.com',
-        maxResults: 5,
+    it('should support filtering by search query', async () => {
+      // This test used to pass `from: 'noreply@example.com'`, which findEmails does not
+      // accept — it was dropped on the way in, so the test filtered nothing and asserted
+      // exactly what the previous test asserted. The tool's actual filter is a search
+      // query across subject and body.
+      const result = await executeTool(findEmails, {
+        searchQuery: 'noreply@example.com',
+        limit: 5,
+        folder: 'inbox',
       });
 
       // Validate structure
       expect(result).toBeDefined();
       expect(Array.isArray(result.emails)).toBe(true);
 
-      console.log('✅ Email filtering by sender works');
+      console.log('✅ Email filtering by search query works');
       console.log('   - Filtered results:', result.emails.length);
       // CRITICAL: Do not log any email details
     }, 30000);

--- a/mcp/mastra/verticals/email/tools.ts
+++ b/mcp/mastra/verticals/email/tools.ts
@@ -170,7 +170,15 @@ export const findEmails = createTool({
       filters.push(`hasAttachments eq ${hasAttachment}`);
     }
 
-    const baseUrl = `${GRAPH_API_BASE}/me/mailFolders/${folder}/messages?$top=${limit}&$orderby=receivedDateTime desc`;
+    // $orderby is omitted whenever a search is being run. Microsoft Graph rejects the
+    // combination outright -- "The query parameter '$orderBy' is not supported with
+    // '$search'" (error code SearchWithOrderBy, HTTP 400) -- so every searchQuery call
+    // this tool ever made failed. It went unnoticed because the only test exercising the
+    // filter passed a parameter name the tool does not accept, so the argument was
+    // dropped and the request never carried a search at all. Graph returns search hits
+    // by relevance, which is the sensible order for a search anyway.
+    const ordering = searchQuery ? '' : '&$orderby=receivedDateTime desc';
+    const baseUrl = `${GRAPH_API_BASE}/me/mailFolders/${folder}/messages?$top=${limit}${ordering}`;
     const filterExpression = filters.length > 0 ? filters.join(' and ') : undefined;
     const url = buildGraphApiUrlWithFilter(baseUrl, filterExpression, searchQuery);
 
@@ -449,7 +457,9 @@ export const sendEmail = createTool({
     bccRecipients: z.array(z.string()).optional().describe('Array of BCC recipient email addresses'),
   }),
   outputSchema: z.object({
-    messageId: z.string(),
+    messageId: z
+      .string()
+      .describe("Always the literal 'sent': Graph's sendMail answers 202 with no body, so there is no id to report"),
     subject: z.string(),
     success: z.boolean(),
     message: z.string(),

--- a/mcp/mastra/verticals/email/workflows.spec.ts
+++ b/mcp/mastra/verticals/email/workflows.spec.ts
@@ -1,0 +1,551 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Mastra } from '@mastra/core';
+import { z } from 'zod';
+import { createStep, createWorkflow } from '../../utils/workflows/workflow-factory.js';
+import * as realHumanInTheLoopAgents from '../human-in-the-loop/agents.js';
+import * as realEmailTools from './tools.js';
+
+/**
+ * Resuming a run from a reply is the only part of the human-in-the-loop loop that lives
+ * in the email vertical, and the only part with a real inbox on one side and a real
+ * mailbox on the other. Both are replaced here: `sendEmail` records instead of calling
+ * Microsoft Graph, and the parsing agent returns a staged answer instead of reaching a
+ * model. Everything between them -- the subject token, the storage lookup, the suspended
+ * step, the sender check -- is the real thing.
+ *
+ * The rest of both modules is spread back in because `mock.module` is process-global in
+ * Bun and other spec files share this process.
+ */
+interface SentEmail {
+  subject: string;
+  bodyContent: string;
+  toRecipients: string[];
+}
+
+const sentEmails: SentEmail[] = [];
+
+mock.module('./tools.js', () => ({
+  ...realEmailTools,
+  sendEmail: {
+    id: 'sendEmail',
+    inputSchema: realEmailTools.sendEmail.inputSchema,
+    outputSchema: realEmailTools.sendEmail.outputSchema,
+    execute: async (inputData: SentEmail) => {
+      sentEmails.push(inputData);
+      return {
+        // What the real tool returns: Graph's sendMail answers 202 with no body.
+        messageId: 'sent',
+        subject: inputData.subject,
+        success: true,
+        message: 'Email sent successfully',
+      };
+    },
+  },
+}));
+
+const parsedReplyBodies: string[] = [];
+let stagedAnswer: unknown;
+let parseFailure: Error | undefined;
+let parserAnswersForThisFile = false;
+
+// Captured before the mock is registered: registering it rewrites the module namespace in
+// place, so reading the export afterwards would find the stand-in.
+const realParseEmailReply = realHumanInTheLoopAgents.parseEmailReply;
+
+// `mock.module` is process-global, so this stand-in answers only while a test in this file
+// is running; `agents.spec.ts` tests the real `parseEmailReply` in the same process.
+mock.module('../human-in-the-loop/agents.js', () => ({
+  ...realHumanInTheLoopAgents,
+  parseEmailReply: async <TResponseSchema extends z.ZodObject<z.ZodRawShape>>(request: {
+    question: string;
+    replyBody: string;
+    responseSchema: TResponseSchema;
+  }) => {
+    if (!parserAnswersForThisFile) {
+      return await realParseEmailReply(request);
+    }
+
+    parsedReplyBodies.push(request.replyBody);
+    if (parseFailure) {
+      throw parseFailure;
+    }
+    return request.responseSchema.parse(stagedAnswer);
+  },
+}));
+
+const { buildFormRequestSubject, getSendEmailAndAwaitResponseWorkflow, humanInTheLoopDemoWorkflow } = await import(
+  '../human-in-the-loop/workflows.js'
+);
+const { formRepliesDetectionWorkflow } = await import('./workflows.js');
+
+/** Narrows a workflow result so the status-specific fields are reachable. */
+function assertStatus<TResult extends { status: string }, TStatus extends TResult['status']>(
+  result: TResult,
+  status: TStatus,
+): asserts result is Extract<TResult, { status: TStatus }> {
+  expect(result.status).toBe(status);
+}
+
+const approvalResponseSchema = z.object({
+  approved: z.boolean(),
+  comments: z.string().optional(),
+});
+
+const awaitApprovalWorkflow = getSendEmailAndAwaitResponseWorkflow('emailReplyUnderTest', approvalResponseSchema);
+
+/**
+ * A suspended run that is not waiting for an email, used to check that the reply handler
+ * looks at what a run is suspended on rather than resuming anything it happens to find.
+ */
+const awaitSomethingElseWorkflow = createWorkflow({
+  id: 'awaitSomethingElseWorkflow',
+  inputSchema: z.object({}),
+  outputSchema: z.object({}),
+})
+  .then(
+    createStep({
+      id: 'await-something-else',
+      description: 'Suspends on a step that has nothing to do with email',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      resumeSchema: z.object({}),
+      suspendSchema: z.object({}),
+      execute: async ({ resumeData, suspend }) => resumeData ?? (await suspend({})),
+    }),
+  )
+  .commit();
+
+const RESUME_FAILURE_MESSAGE = 'the ledger refused the approval';
+
+/**
+ * A run that accepts the reply and then dies on the next step, so the resume comes back
+ * `failed`. The reason has to survive the trip: Mastra serialises the error before the
+ * result leaves the engine, so reading `.message` straight off it is reading a field of
+ * whatever shape happened to come back.
+ */
+const failsAfterReplyWorkflow = createWorkflow({
+  id: 'failsAfterReplyWorkflow',
+  inputSchema: z.object({ recipientEmail: z.string(), question: z.string() }),
+  outputSchema: z.object({}),
+})
+  .then(getSendEmailAndAwaitResponseWorkflow('failingUnderTest', approvalResponseSchema))
+  .then(
+    createStep({
+      id: 'explode-once-the-answer-is-in',
+      description: 'Throws, so resuming this run reports a failure rather than a refusal',
+      inputSchema: z.object({ senderEmail: z.string(), response: approvalResponseSchema }),
+      outputSchema: z.object({}),
+      execute: async () => {
+        throw new Error(RESUME_FAILURE_MESSAGE);
+      },
+    }),
+  )
+  .commit();
+
+// The state the form replies workflow builds up before `process-form-replies` reads it.
+const emailStateSchema = z
+  .object({
+    newEmails: z.array(z.unknown()).default([]),
+    isFirstCheck: z.boolean().default(false),
+  })
+  .partial();
+
+const formReplyHarness = createWorkflow({
+  id: 'formReplyHarness',
+  inputSchema: z.object({ emailCount: z.number(), isFirstCheck: z.boolean() }),
+  outputSchema: z.object({
+    emailsProcessed: z.number(),
+    formRepliesFound: z.number(),
+    workflowsResumed: z.number(),
+    repliesRejected: z.number(),
+    errors: z.array(z.string()),
+  }),
+  stateSchema: emailStateSchema,
+})
+  .then(formRepliesDetectionWorkflow.steps['process-form-replies'])
+  .commit();
+
+const mastra = new Mastra({
+  workflows: {
+    awaitApprovalWorkflow,
+    awaitSomethingElseWorkflow,
+    failsAfterReplyWorkflow,
+    humanInTheLoopDemoWorkflow,
+    formReplyHarness,
+  },
+});
+
+let nextEmailId = 0;
+
+function inboundReply({
+  subject,
+  from,
+  content = '',
+  preview = '',
+}: {
+  subject: string;
+  from: string;
+  content?: string;
+  preview?: string;
+}) {
+  nextEmailId += 1;
+  return {
+    id: `email-${nextEmailId}`,
+    subject,
+    bodyPreview: preview,
+    body: { contentType: 'text', content },
+    from: { name: from, address: from },
+    receivedDateTime: '2026-08-20T09:00:00Z',
+    isRead: false,
+    hasAttachments: false,
+    isDraft: false,
+  };
+}
+
+async function processReplies(emails: ReturnType<typeof inboundReply>[]) {
+  const run = await mastra.getWorkflow('formReplyHarness').createRun();
+  const result = await run.start({
+    inputData: { emailCount: emails.length, isFirstCheck: false },
+    initialState: { newEmails: emails, isFirstCheck: false },
+  });
+
+  assertStatus(result, 'success');
+  return result.result;
+}
+
+async function startPendingApproval(recipientEmail: string) {
+  const run = await mastra.getWorkflow('awaitApprovalWorkflow').createRun();
+  const started = await run.start({ inputData: { recipientEmail, question: 'Approve the budget?' } });
+  assertStatus(started, 'suspended');
+  return run;
+}
+
+/**
+ * The subject a mail client puts on a reply to the request email at `index` in the outbox.
+ *
+ * Replies are built from the email that was actually sent rather than from a hand-written
+ * token, because the token names one specific question and only the sender knows its id.
+ */
+function replySubjectFor(index: number): string {
+  const email = sentEmails[index];
+  if (!email) {
+    throw new Error(`No request email was sent at index ${index}; the outbox holds ${sentEmails.length}.`);
+  }
+
+  return `Re: ${email.subject}`;
+}
+
+beforeEach(() => {
+  sentEmails.length = 0;
+  parsedReplyBodies.length = 0;
+  stagedAnswer = undefined;
+  parseFailure = undefined;
+  parserAnswersForThisFile = true;
+});
+
+afterEach(() => {
+  // Outside this file's tests the recorder steps aside; see the note on the mock.
+  parserAnswersForThisFile = false;
+});
+
+describe('processFormReplies', () => {
+  it('reports nothing when there are no emails at all', async () => {
+    expect(await processReplies([])).toEqual({
+      emailsProcessed: 0,
+      formRepliesFound: 0,
+      workflowsResumed: 0,
+      repliesRejected: 0,
+      errors: [],
+    });
+  });
+
+  it('ignores ordinary mail that carries no run token', async () => {
+    const summary = await processReplies([
+      inboundReply({ subject: 'Lunch?', from: 'colleague@example.com', content: 'Sushi at noon' }),
+    ]);
+
+    expect(summary).toEqual({
+      emailsProcessed: 1,
+      formRepliesFound: 0,
+      workflowsResumed: 0,
+      repliesRejected: 0,
+      errors: [],
+    });
+  });
+
+  it('resumes the run named in the subject and finishes it with the parsed reply', async () => {
+    const run = await startPendingApproval('boss@example.com');
+    stagedAnswer = { approved: true, comments: 'go ahead' };
+
+    const summary = await processReplies([
+      inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: 'Yes, go ahead' }),
+    ]);
+
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 1, repliesRejected: 0, errors: [] });
+    expect(parsedReplyBodies).toEqual(['Yes, go ahead']);
+
+    const finished = await mastra.getWorkflow('awaitApprovalWorkflow').getWorkflowRunById(run.runId);
+    expect(finished?.status).toBe('success');
+    expect(finished?.result).toEqual({
+      senderEmail: 'boss@example.com',
+      response: { approved: true, comments: 'go ahead' },
+    });
+  });
+
+  it('falls back to the preview when the body did not come back', async () => {
+    await startPendingApproval('boss@example.com');
+    stagedAnswer = { approved: false };
+
+    await processReplies([
+      inboundReply({
+        subject: replySubjectFor(0),
+        from: 'boss@example.com',
+        content: '',
+        preview: 'No, too expensive',
+      }),
+    ]);
+
+    expect(parsedReplyBodies).toEqual(['No, too expensive']);
+  });
+
+  it('refuses a reply with nothing in it rather than asking the model to read a blank', async () => {
+    const run = await startPendingApproval('boss@example.com');
+
+    const summary = await processReplies([
+      inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: '   ', preview: '' }),
+    ]);
+
+    // `body.content || bodyPreview` is `''` when both are empty, and an empty string used
+    // to sail past the `replyBody === undefined` guard straight into the parsing agent.
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 0, repliesRejected: 1, errors: [] });
+    expect(parsedReplyBodies).toEqual([]);
+    expect((await mastra.getWorkflow('awaitApprovalWorkflow').getWorkflowRunById(run.runId))?.status).toBe('suspended');
+  });
+
+  it('drives a multi-stage run on to its next question', async () => {
+    const demoRun = await mastra.getWorkflow('humanInTheLoopDemoWorkflow').createRun();
+    const started = await demoRun.start({
+      inputData: { recipientEmail: 'boss@example.com', projectName: 'Atlas', budgetAmount: 2500 },
+    });
+    assertStatus(started, 'suspended');
+    expect(sentEmails).toHaveLength(1);
+
+    stagedAnswer = { approved: true };
+    const summary = await processReplies([
+      inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: 'Approved' }),
+    ]);
+
+    expect(summary).toMatchObject({ workflowsResumed: 1, errors: [] });
+    // The reply moved the run on, so the next question is already in the outbox.
+    expect(sentEmails).toHaveLength(2);
+    expect(sentEmails[1].subject).toContain('Please select a vendor for project "Atlas".');
+  });
+
+  it('refuses a second reply to an answered email instead of feeding it to the next question', async () => {
+    const demoRun = await mastra.getWorkflow('humanInTheLoopDemoWorkflow').createRun();
+    const started = await demoRun.start({
+      inputData: { recipientEmail: 'boss@example.com', projectName: 'Atlas', budgetAmount: 2500 },
+    });
+    assertStatus(started, 'suspended');
+    const budgetReplySubject = replySubjectFor(0);
+
+    stagedAnswer = { approved: true };
+    const firstSummary = await processReplies([
+      inboundReply({ subject: budgetReplySubject, from: 'boss@example.com', content: 'Yes go ahead' }),
+    ]);
+
+    expect(firstSummary).toMatchObject({ workflowsResumed: 1, repliesRejected: 0, errors: [] });
+    expect(sentEmails).toHaveLength(2);
+    expect(sentEmails[1].subject).toContain('Please select a vendor for project "Atlas".');
+
+    // The same person replies to the same budget email a second time. Nothing about that
+    // email says "vendor", but the run has moved on to the vendor question, and a token
+    // carrying only the run id matched it: the parser was handed "Yes go ahead" as a
+    // vendor choice and the run mailed out
+    // `Final confirmation for project "Atlas" with vendor "Yes go ahead"`.
+    stagedAnswer = { vendorName: 'Yes go ahead', justification: 'Yes go ahead' };
+    const secondSummary = await processReplies([
+      inboundReply({ subject: budgetReplySubject, from: 'boss@example.com', content: 'Yes go ahead' }),
+    ]);
+
+    expect(secondSummary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 0, repliesRejected: 1, errors: [] });
+    // The vendor question never saw the budget reply, and no further email went out.
+    expect(parsedReplyBodies).toEqual(['Yes go ahead']);
+    expect(sentEmails).toHaveLength(2);
+    expect(sentEmails.some((email) => email.subject.includes('vendor "Yes go ahead"'))).toBe(false);
+
+    // The refusal leaves the vendor question open for a real answer.
+    const stillPending = await mastra.getWorkflow('humanInTheLoopDemoWorkflow').getWorkflowRunById(demoRun.runId);
+    expect(stillPending?.status).toBe('suspended');
+
+    stagedAnswer = { vendorName: 'Acme', justification: 'Cheapest bid' };
+    const thirdSummary = await processReplies([
+      inboundReply({ subject: replySubjectFor(1), from: 'boss@example.com', content: 'Go with Acme' }),
+    ]);
+
+    expect(thirdSummary).toMatchObject({ workflowsResumed: 1, repliesRejected: 0, errors: [] });
+    expect(sentEmails).toHaveLength(3);
+    expect(sentEmails[2].subject).toContain('Final confirmation for project "Atlas" with vendor "Acme".');
+  });
+
+  it('refuses a reply to an earlier question while a later one is waiting', async () => {
+    const demoRun = await mastra.getWorkflow('humanInTheLoopDemoWorkflow').createRun();
+    assertStatus(
+      await demoRun.start({
+        inputData: { recipientEmail: 'boss@example.com', projectName: 'Atlas', budgetAmount: 2500 },
+      }),
+      'suspended',
+    );
+
+    stagedAnswer = { approved: true };
+    await processReplies([
+      inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: 'Approved' }),
+    ]);
+    stagedAnswer = { vendorName: 'Acme', justification: 'Cheapest bid' };
+    await processReplies([inboundReply({ subject: replySubjectFor(1), from: 'boss@example.com', content: 'Acme' })]);
+    expect(sentEmails).toHaveLength(3);
+
+    // Stage three is the question now open; this answers stage two, two hops behind.
+    stagedAnswer = { confirmed: true };
+    const summary = await processReplies([
+      inboundReply({ subject: replySubjectFor(1), from: 'boss@example.com', content: 'Actually make it Globex' }),
+    ]);
+
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 0, repliesRejected: 1, errors: [] });
+    expect(sentEmails).toHaveLength(3);
+    expect((await mastra.getWorkflow('humanInTheLoopDemoWorkflow').getWorkflowRunById(demoRun.runId))?.status).toBe(
+      'suspended',
+    );
+  });
+
+  it('counts a reply from the wrong person as rejected and leaves the run waiting', async () => {
+    const run = await startPendingApproval('boss@example.com');
+    stagedAnswer = { approved: true };
+
+    const summary = await processReplies([
+      inboundReply({ subject: replySubjectFor(0), from: 'attacker@example.com', content: 'Yes, approved' }),
+    ]);
+
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 0, repliesRejected: 1, errors: [] });
+    // The point of refusing rather than failing: the person who was asked can still answer.
+    expect(parsedReplyBodies).toEqual([]);
+
+    const stillPending = await mastra.getWorkflow('awaitApprovalWorkflow').getWorkflowRunById(run.runId);
+    expect(stillPending?.status).toBe('suspended');
+
+    const secondSummary = await processReplies([
+      inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: 'Yes, approved' }),
+    ]);
+
+    expect(secondSummary).toMatchObject({ workflowsResumed: 1, repliesRejected: 0 });
+  });
+
+  it('counts a reply the parser cannot read as rejected', async () => {
+    const run = await startPendingApproval('boss@example.com');
+    parseFailure = new Error('The email parsing agent returned no structured response');
+
+    const summary = await processReplies([
+      inboundReply({
+        subject: replySubjectFor(0),
+        from: 'boss@example.com',
+        content: 'I will get back to you next week',
+      }),
+    ]);
+
+    expect(summary).toMatchObject({ workflowsResumed: 0, repliesRejected: 1, errors: [] });
+    const stillPending = await mastra.getWorkflow('awaitApprovalWorkflow').getWorkflowRunById(run.runId);
+    expect(stillPending?.status).toBe('suspended');
+  });
+
+  it('records an error when no run at all answers to the token', async () => {
+    const summary = await processReplies([
+      inboundReply({
+        subject: `Re: ${buildFormRequestSubject({
+          runId: 'nobody-is-waiting-for-this',
+          requestId: 'req-nobody-asked',
+          question: 'Approve the budget?',
+        })}`,
+        from: 'boss@example.com',
+        content: 'Yes',
+      }),
+    ]);
+
+    // A token naming a run that does not exist is an anomaly worth reporting, unlike a
+    // reply that simply arrived too late for the run it names.
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 0, repliesRejected: 0 });
+    expect(summary.errors).toEqual(['No workflow run with id nobody-is-waiting-for-this was found']);
+  });
+
+  it('refuses a reply to a question the run has already finished answering', async () => {
+    const run = await startPendingApproval('boss@example.com');
+    stagedAnswer = { approved: true };
+    const reply = () => inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: 'Yes' });
+
+    expect(await processReplies([reply()])).toMatchObject({ workflowsResumed: 1, repliesRejected: 0 });
+    const summary = await processReplies([reply()]);
+
+    // "No such run" and "that run is not waiting for an email" used to share one message,
+    // which hid a reply arriving after its question had already been answered.
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 0, repliesRejected: 1, errors: [] });
+    expect(parsedReplyBodies).toEqual(['Yes']);
+    expect((await mastra.getWorkflow('awaitApprovalWorkflow').getWorkflowRunById(run.runId))?.status).toBe('success');
+  });
+
+  it('reports why a resume failed, reading the message out of the error Mastra serialised', async () => {
+    const run = await mastra.getWorkflow('failsAfterReplyWorkflow').createRun();
+    assertStatus(
+      await run.start({ inputData: { recipientEmail: 'boss@example.com', question: 'Approve?' } }),
+      'suspended',
+    );
+    stagedAnswer = { approved: true };
+
+    const summary = await processReplies([
+      inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: 'Yes' }),
+    ]);
+
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 0, repliesRejected: 0 });
+    expect(summary.errors).toEqual([
+      `Error processing email "${replySubjectFor(0)}": Resuming failsAfterReplyWorkflow run ${run.runId} failed: ${RESUME_FAILURE_MESSAGE}`,
+    ]);
+  });
+
+  it('leaves a run suspended on something other than an email question alone', async () => {
+    const otherRun = await mastra.getWorkflow('awaitSomethingElseWorkflow').createRun();
+    const started = await otherRun.start({ inputData: {} });
+    assertStatus(started, 'suspended');
+
+    const summary = await processReplies([
+      inboundReply({
+        subject: `Re: ${buildFormRequestSubject({
+          runId: otherRun.runId,
+          requestId: 'req-not-an-email-question',
+          question: 'Approve the budget?',
+        })}`,
+        from: 'boss@example.com',
+        content: 'Yes',
+      }),
+    ]);
+
+    expect(summary).toMatchObject({ workflowsResumed: 0, repliesRejected: 1, errors: [] });
+    expect((await mastra.getWorkflow('awaitSomethingElseWorkflow').getWorkflowRunById(otherRun.runId))?.status).toBe(
+      'suspended',
+    );
+  });
+
+  it('keeps going after one reply cannot be matched', async () => {
+    await startPendingApproval('boss@example.com');
+    stagedAnswer = { approved: true };
+
+    const summary = await processReplies([
+      inboundReply({
+        subject: `Re: ${buildFormRequestSubject({ runId: 'gone', requestId: 'req-gone', question: 'Approve?' })}`,
+        from: 'boss@example.com',
+        content: 'Yes',
+      }),
+      inboundReply({ subject: replySubjectFor(0), from: 'boss@example.com', content: 'Yes' }),
+    ]);
+
+    expect(summary).toMatchObject({ emailsProcessed: 2, formRepliesFound: 2, workflowsResumed: 1 });
+    expect(summary.errors).toHaveLength(1);
+  });
+});

--- a/mcp/mastra/verticals/email/workflows.ts
+++ b/mcp/mastra/verticals/email/workflows.ts
@@ -1,16 +1,24 @@
+import type { Mastra } from '@mastra/core';
 import { z } from 'zod';
+import { extractErrorMessage } from '../../utils/errors.js';
 import { executeTool } from '../../utils/tool-factory.js';
-import { createStep, createWorkflow } from '../../utils/workflows/workflow-factory.js';
+import {
+  createStep,
+  createWorkflow,
+  createWorkflowStateReader,
+  type WorkflowSuspendedStep,
+} from '../../utils/workflows/workflow-factory.js';
+import { parseFormRequestSubject } from '../human-in-the-loop/workflows.js';
 import { registerStateChange } from '../synapse/tools.js';
 import { findNewEmailsSinceLastCheck, updateLastSeenEmail } from './tools.js';
 import { processEmailTriggers } from './triggers.js';
 
 /**
- * Regex pattern to extract workflow ID from email subjects.
- * Matches: [WF-{workflowId}]
- * Example: "Re: Form Request [WF-abc123]: Please approve..."
+ * Id of the suspending step inside every send-and-wait workflow. A form reply can only be
+ * applied to a run that is waiting on one of these, so the id is checked before resuming
+ * rather than assuming any suspended run wants an email.
  */
-const WORKFLOW_ID_REGEX = /\[WF-([^\]]+)\]/;
+const AWAIT_EMAIL_RESPONSE_STEP_ID = 'await-email-response';
 
 /**
  * Creates an empty form reply processing result.
@@ -20,11 +28,13 @@ const createEmptyFormReplyResult = (): {
   emailsProcessed: number;
   formRepliesFound: number;
   workflowsResumed: number;
+  repliesRejected: number;
   errors: string[];
 } => ({
   emailsProcessed: 0,
   formRepliesFound: 0,
   workflowsResumed: 0,
+  repliesRejected: 0,
   errors: [],
 });
 
@@ -63,6 +73,21 @@ const sharedEmailStateSchema = z
     lastCheckTimestamp: z.string().optional(),
     mostRecentEmailId: z.string().optional(),
     mostRecentEmailReceivedDateTime: z.string().optional(),
+    /**
+     * What processing the replies actually did.
+     *
+     * Carried in state because the steps between that work and the workflow's final
+     * output do not thread it through their schemas, and a refused reply that appears
+     * only in a console line is a refusal nobody finds. A scheduled run's own result
+     * should say when it declined to apply an answer.
+     */
+    formReplyOutcome: z
+      .object({
+        workflowsResumed: z.number(),
+        repliesRejected: z.number(),
+        errors: z.array(z.string()),
+      })
+      .optional(),
   })
   .partial();
 
@@ -320,11 +345,184 @@ export const emailCheckingWorkflow = createWorkflow({
 // ============================================================================
 
 /**
- * Process form replies and extract workflow IDs
+ * Whether the step a run is suspended on is one of the send-and-wait steps an email reply
+ * can answer.
+ */
+function isAwaitingEmailReply(suspendedPath: string[] | undefined): boolean {
+  const path = suspendedPath ?? [];
+  return path[path.length - 1] === AWAIT_EMAIL_RESPONSE_STEP_ID;
+}
+
+/**
+ * Says why a run that was found cannot take the reply that named it.
+ *
+ * "No run with that id" and "that run is not waiting for an email" used to share one
+ * message, which hid the difference between a token pointing at nothing and a reply that
+ * arrived after its question had already been answered.
+ */
+function describeRunThatCannotTakeTheReply(
+  workflowId: string,
+  runId: string,
+  status: string,
+  suspendedPath: string[] | undefined,
+): string {
+  if (status !== 'suspended') {
+    return `Run ${runId} of ${workflowId} is not waiting for a reply; it is ${status}`;
+  }
+
+  if (!suspendedPath || suspendedPath.length === 0) {
+    return `Run ${runId} of ${workflowId} is suspended, but its snapshot names no suspended step`;
+  }
+
+  return `Run ${runId} of ${workflowId} is suspended on ${suspendedPath.join(' > ')}, which is not an email question`;
+}
+
+/** A workflow as it comes back from the registry the reply handler searches. */
+type RegisteredWorkflow = ReturnType<Mastra['listWorkflows']>[string];
+
+/**
+ * What the run named by a reply turned out to be.
+ */
+type RunLookup =
+  | { kind: 'awaiting'; workflow: RegisteredWorkflow; suspendedStep: WorkflowSuspendedStep }
+  | { kind: 'not-awaiting'; description: string }
+  | { kind: 'not-found'; description: string };
+
+/**
+ * Finds the suspended run that a form reply belongs to.
+ *
+ * The subject carries a run id because that is the only identifier a step suspended
+ * inside a nested workflow shares with the top-level run it belongs to. `getWorkflowRunById`
+ * filters by the workflow's own name, so the owning workflow is found by asking each
+ * registered workflow whether it holds that run — a handful of indexed lookups, on a job
+ * that runs every three hours.
+ *
+ * `withNestedWorkflows: false` because nothing here needs the nested step results the
+ * default recursively re-reads: a nested suspension is located from the top-level step's
+ * own `__workflow_meta` path, which is in the snapshot either way.
+ *
+ * A run that is found but cannot take the reply does not end the search, because a run id
+ * is only unique per workflow; the reason is reported only if no workflow is waiting.
+ */
+async function findRunAwaitingEmailReply(mastra: Mastra, runId: string): Promise<RunLookup> {
+  let firstRunThatCannotTakeIt: string | undefined;
+
+  for (const workflow of Object.values(mastra.listWorkflows())) {
+    const state = await workflow.getWorkflowRunById(runId, { withNestedWorkflows: false });
+    if (!state) {
+      continue;
+    }
+
+    const suspendedStep =
+      state.status === 'suspended' ? createWorkflowStateReader(state).getSuspendedStep() : undefined;
+
+    const suspendedPath = suspendedStep?.path;
+
+    if (suspendedStep && isAwaitingEmailReply(suspendedPath)) {
+      return { kind: 'awaiting', workflow, suspendedStep };
+    }
+
+    firstRunThatCannotTakeIt ??= describeRunThatCannotTakeTheReply(workflow.id, runId, state.status, suspendedPath);
+  }
+
+  return firstRunThatCannotTakeIt
+    ? { kind: 'not-awaiting', description: firstRunThatCannotTakeIt }
+    : { kind: 'not-found', description: `No workflow run with id ${runId} was found` };
+}
+
+/**
+ * The outcome of handing one inbound reply to the run it names.
+ *
+ * `rejected` is its own outcome rather than an error: the reply is one nobody can act on
+ * — the wrong sender, an answer to a question that has already moved on, or text that
+ * cannot be read as an answer — so it is declined and the run is left exactly as it was.
+ * Nothing has gone wrong with the system, and the person who was asked can still answer.
+ */
+type FormReplyOutcome =
+  | { kind: 'resumed'; description: string }
+  | { kind: 'rejected'; description: string }
+  | { kind: 'unmatched'; description: string };
+
+/**
+ * Picks the text of the reply to hand the parser.
+ *
+ * The full body carries the whole answer; `bodyPreview` is truncated and only stands in
+ * when the body did not come back. Either can be blank, and blank is not an answer, so
+ * nothing is passed on rather than a `''` the parsing agent would be asked to read
+ * meaning into.
+ */
+function readReplyText(email: z.infer<typeof emailObjectSchema>): string | undefined {
+  return [email.body.content, email.bodyPreview].find((text) => text.trim() !== '');
+}
+
+/**
+ * Hands one reply to the suspended run named in its subject.
+ *
+ * Both halves of the subject token are used: the run id finds the run, and the request id
+ * is handed to the suspended step, which accepts the reply only if it is the answer to the
+ * request it is actually waiting on.
+ *
+ * A run left suspended at the same step is how a refusal is told apart from an answer that
+ * moved the run on: an accepted answer either finishes the run or suspends it somewhere
+ * else, on its next question.
+ */
+async function applyFormReply(
+  mastra: Mastra,
+  email: z.infer<typeof emailObjectSchema>,
+  { runId, requestId }: { runId: string; requestId: string },
+): Promise<FormReplyOutcome> {
+  const pendingRun = await findRunAwaitingEmailReply(mastra, runId);
+  if (pendingRun.kind === 'not-found') {
+    return { kind: 'unmatched', description: pendingRun.description };
+  }
+
+  if (pendingRun.kind === 'not-awaiting') {
+    return { kind: 'rejected', description: `Reply from ${email.from.address} was refused: ${pendingRun.description}` };
+  }
+
+  const { workflow, suspendedStep } = pendingRun;
+  const run = await workflow.createRun({ runId });
+  const resumed = await run.resume({
+    step: suspendedStep.path,
+    resumeData: {
+      requestId,
+      senderEmail: email.from.address,
+      replyBody: readReplyText(email),
+    },
+  });
+
+  if (resumed.status === 'failed') {
+    const detail = extractErrorMessage(resumed.error) ?? 'no reason was reported';
+    throw new Error(`Resuming ${workflow.id} run ${runId} failed: ${detail}`);
+  }
+
+  const stillWaitingForTheSameAnswer =
+    resumed.status === 'suspended' &&
+    resumed.suspended.some((path) => path.join(' > ') === suspendedStep.path.join(' > '));
+
+  if (stillWaitingForTheSameAnswer) {
+    return {
+      kind: 'rejected',
+      description: `Reply from ${email.from.address} was refused; run ${runId} is still waiting`,
+    };
+  }
+
+  return { kind: 'resumed', description: `Resumed ${workflow.id} run ${runId} (now ${resumed.status})` };
+}
+
+/**
+ * Process form replies and resume the runs waiting for them.
+ *
+ * A reply carries, in its subject, the id of the suspended run and the id of the request
+ * it answers. The run is recovered from storage, and the reply is handed to the step that
+ * suspended, which checks that the reply answers the request it is still waiting on,
+ * validates the sender, and parses the free text into the answer it expects. A reply that
+ * step refuses leaves the run suspended at the same place, which is how a refusal is told
+ * apart from an answer that moved the run on to its next question.
  */
 const processFormReplies = createStep({
   id: 'process-form-replies',
-  description: 'Process emails to extract workflow IDs and attempt to resume workflows',
+  description: 'Process emails to find the suspended runs they answer, and resume them',
   stateSchema: sharedEmailStateSchema,
   inputSchema: z.object({
     emailCount: z.number(),
@@ -334,13 +532,15 @@ const processFormReplies = createStep({
     emailsProcessed: z.number(),
     formRepliesFound: z.number(),
     workflowsResumed: z.number(),
+    repliesRejected: z.number(),
     errors: z.array(z.string()),
   }),
   execute: async (params) => {
     const { newEmails = [] } = params.state;
     let emailsProcessed = 0;
     let formRepliesFound = 0;
-    const workflowsResumed = 0;
+    let workflowsResumed = 0;
+    let repliesRejected = 0;
     const errors: string[] = [];
 
     if (newEmails.length === 0) {
@@ -354,25 +554,27 @@ const processFormReplies = createStep({
       try {
         emailsProcessed++;
 
-        const match = email.subject.match(WORKFLOW_ID_REGEX);
-        if (!match) continue;
+        const formRequest = parseFormRequestSubject(email.subject);
+        if (!formRequest) continue;
 
         formRepliesFound++;
-        const workflowId = match[1];
-        console.log(`✅ Found form reply with workflow ID: ${workflowId} from ${email.from.address}`);
+        const { runId, requestId } = formRequest;
+        console.log(`✅ Found reply to request ${requestId} of run ${runId} from ${email.from.address}`);
 
         if (!params.mastra) {
           throw new Error('Mastra instance not available');
         }
 
-        const workflow = params.mastra.getWorkflow('humanInTheLoopDemoWorkflow');
-        if (!workflow) {
-          errors.push(`Workflow 'humanInTheLoopDemoWorkflow' not found for ID ${workflowId}`);
-          continue;
+        const outcome = await applyFormReply(params.mastra, email, formRequest);
+        if (outcome.kind === 'resumed') {
+          workflowsResumed++;
+          console.log(`▶️  ${outcome.description}`);
+        } else if (outcome.kind === 'rejected') {
+          repliesRejected++;
+          console.log(`🚫 ${outcome.description}`);
+        } else {
+          errors.push(outcome.description);
         }
-
-        console.log(`⚠️  Workflow run retrieval not yet implemented. Skipping workflow ${workflowId}`);
-        errors.push(`Workflow run retrieval not implemented for ${workflowId}`);
       } catch (error) {
         const errorMessage = `Error processing email "${email.subject}": ${error instanceof Error ? error.message : String(error)}`;
         errors.push(errorMessage);
@@ -384,9 +586,12 @@ const processFormReplies = createStep({
     console.log(`   Emails processed: ${emailsProcessed}`);
     console.log(`   Form replies found: ${formRepliesFound}`);
     console.log(`   Workflows resumed: ${workflowsResumed}`);
+    console.log(`   Replies rejected: ${repliesRejected}`);
     console.log(`   Errors: ${errors.length}`);
 
-    return { emailsProcessed, formRepliesFound, workflowsResumed, errors };
+    params.setState({ ...params.state, formReplyOutcome: { workflowsResumed, repliesRejected, errors } });
+
+    return { emailsProcessed, formRepliesFound, workflowsResumed, repliesRejected, errors };
   },
 });
 
@@ -403,6 +608,7 @@ const registerEmailsStateChange = createStep({
     emailsProcessed: z.number(),
     formRepliesFound: z.number(),
     workflowsResumed: z.number(),
+    repliesRejected: z.number(),
     errors: z.array(z.string()),
   }),
   outputSchema: z.object({
@@ -429,6 +635,7 @@ const registerEmailsStateChange = createStep({
         emailCount: emails.length,
         formRepliesFound: inputData.formRepliesFound,
         workflowsResumed: inputData.workflowsResumed,
+        repliesRejected: inputData.repliesRejected,
         emails: emails.map((email: z.infer<typeof emailObjectSchema>) => ({
           subject: email.subject,
           from: email.from.address,
@@ -518,24 +725,42 @@ const formatFormRepliesOutput = createStep({
   outputSchema: z.object({
     emailsFound: z.number(),
     formRepliesDetected: z.number(),
+    workflowsResumed: z.number(),
+    repliesRejected: z.number(),
+    errors: z.array(z.string()),
     stateChangeRegistered: z.boolean(),
     message: z.string(),
   }),
   execute: async (params) => {
     const emails = params.state.newEmails ?? [];
 
-    const formRepliesCount = emails.filter((email: z.infer<typeof emailObjectSchema>) =>
-      WORKFLOW_ID_REGEX.test(email.subject),
+    const formRepliesCount = emails.filter(
+      (email: z.infer<typeof emailObjectSchema>) => parseFormRequestSubject(email.subject) !== undefined,
     ).length;
+
+    const outcome = params.state.formReplyOutcome ?? { workflowsResumed: 0, repliesRejected: 0, errors: [] };
+
+    // A refusal is reported alongside the counts rather than buried, because "we saw a
+    // reply and deliberately did not apply it" is the one outcome an operator has to act
+    // on -- somebody is waiting on an approval that is not going to arrive.
+    const appliedSummary =
+      outcome.repliesRejected > 0
+        ? `, resumed ${outcome.workflowsResumed}, refused ${outcome.repliesRejected}`
+        : outcome.workflowsResumed > 0
+          ? `, resumed ${outcome.workflowsResumed}`
+          : '';
 
     return {
       emailsFound: emails.length,
       formRepliesDetected: formRepliesCount,
+      workflowsResumed: outcome.workflowsResumed,
+      repliesRejected: outcome.repliesRejected,
+      errors: outcome.errors,
       stateChangeRegistered: emails.length > 0,
       message:
         emails.length === 0
           ? 'No new emails to analyze'
-          : `Analyzed ${emails.length} email(s), found ${formRepliesCount} form ${formRepliesCount === 1 ? 'reply' : 'replies'}`,
+          : `Analyzed ${emails.length} email(s), found ${formRepliesCount} form ${formRepliesCount === 1 ? 'reply' : 'replies'}${appliedSummary}`,
     };
   },
 });
@@ -545,8 +770,8 @@ const formatFormRepliesOutput = createStep({
  *
  * Workflow that processes emails for form replies and triggers the state reactor.
  * This workflow runs less frequently (every 3 hours) and is responsible for:
- * 1. Detecting form reply emails (with [WF-{id}] pattern)
- * 2. Attempting to resume suspended workflows
+ * 1. Detecting form reply emails (with the [RUN-{runId}/REQ-{requestId}] token)
+ * 2. Resuming the suspended runs those replies answer
  * 3. Registering state changes to trigger notifications
  *
  * Uses its own storage key ('inbox-form-replies') to track which emails have been
@@ -557,7 +782,7 @@ const formatFormRepliesOutput = createStep({
  * Workflow Steps:
  * 1. Search for new emails since last check
  * 2. Store emails in state
- * 3. Process form replies (extract workflow IDs, resume workflows)
+ * 3. Process form replies (read the subject token, resume the run that request belongs to)
  * 4. Register state change (triggers state reactor for notifications)
  * 5. Update last seen email tracking
  * 6. Format output
@@ -568,6 +793,9 @@ export const formRepliesDetectionWorkflow = createWorkflow({
   outputSchema: z.object({
     emailsFound: z.number(),
     formRepliesDetected: z.number(),
+    workflowsResumed: z.number(),
+    repliesRejected: z.number(),
+    errors: z.array(z.string()),
     stateChangeRegistered: z.boolean(),
     message: z.string(),
   }),

--- a/mcp/mastra/verticals/human-in-the-loop/agents.spec.ts
+++ b/mcp/mastra/verticals/human-in-the-loop/agents.spec.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { z } from 'zod';
+import * as realAgentFactory from '../../utils/agent-factory.js';
+
+/**
+ * `parseEmailReply` is the only thing in this vertical that talks to a model, so the model
+ * is the only thing replaced.
+ *
+ * `createAgent` still builds the real agent for everybody else: `mock.module` is
+ * process-global in Bun, and other spec files sharing this process create real agents. It
+ * hands back a stand-in only for the parsing agent, and only while a test has staged what
+ * the model should answer -- which is why the tests below that inspect the real agent's
+ * configuration still see the real thing.
+ */
+interface StagedGeneration {
+  object?: unknown;
+  failure?: Error;
+}
+
+let stagedGeneration: StagedGeneration | undefined;
+const generateCalls: Array<{ prompt: string; options: unknown }> = [];
+
+// Captured before the module is replaced: `mock.module` rewrites the namespace object in
+// place, so reading `realAgentFactory.createAgent` later would find the replacement and
+// call it forever.
+const createRealAgent = realAgentFactory.createAgent;
+
+mock.module('../../utils/agent-factory.js', () => ({
+  ...realAgentFactory,
+  createAgent: async (config: Parameters<typeof createRealAgent>[0]) => {
+    const staged = stagedGeneration;
+    if (config.id !== 'emailResponseParser' || !staged) {
+      return await createRealAgent(config);
+    }
+
+    return {
+      id: config.id,
+      name: config.name,
+      generate: async (messages: Array<{ role: string; content: string }>, options: unknown) => {
+        generateCalls.push({ prompt: messages.map((message) => message.content).join('\n'), options });
+        if (staged.failure) {
+          throw staged.failure;
+        }
+        return { object: staged.object };
+      },
+    };
+  },
+}));
+
+const { buildEmailParsingPrompt, getEmailParsingAgent, parseEmailReply } = await import('./agents.js');
+
+/**
+ * Constructing the agent neither contacts the model provider nor needs an API key,
+ * so these tests only pin down the configuration. Nothing here calls `generate()`.
+ */
+describe('getEmailParsingAgent', () => {
+  it('identifies itself as the email response parser', async () => {
+    const agent = await getEmailParsingAgent();
+
+    expect(agent.id).toBe('emailResponseParser');
+    expect(agent.name).toBe('EmailResponseParser');
+  });
+
+  it('instructs the model how to interpret informal replies', async () => {
+    const agent = await getEmailParsingAgent();
+
+    const instructions = await agent.getInstructions();
+    expect(typeof instructions).toBe('string');
+    expect(instructions).toContain('parsing email responses');
+    expect(instructions).toContain('interpret as approval');
+    expect(instructions).toContain('interpret as rejection');
+    expect(instructions).toContain('use null or empty values');
+  });
+
+  it('warns the model that replies arrive as HTML wrapped around quoted history', async () => {
+    const agent = await getEmailParsingAgent();
+
+    // A reply body comes straight off Microsoft Graph: markup included, and usually with
+    // the original request quoted underneath the answer.
+    const instructions = await agent.getInstructions();
+    expect(instructions).toContain('ignore the markup and the quoted history');
+  });
+
+  it('has no tools of its own', async () => {
+    const agent = await getEmailParsingAgent();
+
+    expect(Object.keys(await agent.listTools())).toEqual([]);
+  });
+});
+
+describe('buildEmailParsingPrompt', () => {
+  it('gives the model the question as well as the reply', () => {
+    const prompt = buildEmailParsingPrompt({
+      question: 'Please approve the budget for project "Atlas".',
+      replyBody: 'Yeah fine, go ahead',
+    });
+
+    // Without the question, "yeah fine" is not enough to decide what was agreed to.
+    expect(prompt).toContain('Please approve the budget for project "Atlas".');
+    expect(prompt).toContain('Yeah fine, go ahead');
+    expect(prompt).toContain('Extract their answer into the requested structure.');
+  });
+
+  it('keeps the reply verbatim rather than trimming or summarising it', () => {
+    const replyBody =
+      '<html><body><p>No &mdash; too expensive</p><blockquote>Please approve...</blockquote></body></html>';
+
+    expect(buildEmailParsingPrompt({ question: 'Approve?', replyBody })).toContain(replyBody);
+  });
+});
+
+describe('parseEmailReply', () => {
+  const approvalSchema = z.object({ approved: z.boolean(), comments: z.string().optional() });
+  const question = 'Please approve the budget for project "Atlas".';
+  const replyBody = 'Yeah fine, go ahead';
+
+  afterEach(() => {
+    stagedGeneration = undefined;
+    generateCalls.length = 0;
+  });
+
+  it('returns the structured answer the model produced', async () => {
+    stagedGeneration = { object: { approved: true, comments: 'go ahead' } };
+
+    expect(await parseEmailReply({ question, replyBody, responseSchema: approvalSchema })).toEqual({
+      approved: true,
+      comments: 'go ahead',
+    });
+  });
+
+  it('asks the model for the caller schema, with the question and the reply, and no tools', async () => {
+    stagedGeneration = { object: { approved: true } };
+
+    await parseEmailReply({ question, replyBody, responseSchema: approvalSchema });
+
+    expect(generateCalls).toHaveLength(1);
+    expect(generateCalls[0].prompt).toBe(buildEmailParsingPrompt({ question, replyBody }));
+    // Tools are refused because reading a reply is a pure extraction: an agent that can
+    // act would be acting on an email a stranger may have written.
+    expect(generateCalls[0].options).toMatchObject({
+      structuredOutput: { schema: approvalSchema },
+      toolChoice: 'none',
+    });
+  });
+
+  it('validates the answer against the caller schema rather than trusting the model', async () => {
+    stagedGeneration = { object: { approved: 'probably' } };
+
+    await expect(parseEmailReply({ question, replyBody, responseSchema: approvalSchema })).rejects.toThrow(/approved/);
+  });
+
+  it('drops fields the schema does not declare', async () => {
+    stagedGeneration = { object: { approved: true, injected: 'ignore me' } };
+
+    expect(await parseEmailReply({ question, replyBody, responseSchema: approvalSchema })).toEqual({ approved: true });
+  });
+
+  it('throws when the model produced no structured response at all', async () => {
+    stagedGeneration = { object: undefined };
+
+    // The caller treats a throw as "this reply did not answer the question", so the
+    // request stays open instead of recording an answer nobody gave.
+    await expect(parseEmailReply({ question, replyBody, responseSchema: approvalSchema })).rejects.toThrow(
+      'The email parsing agent returned no structured response',
+    );
+  });
+
+  it('throws when the model answered with a bare null', async () => {
+    stagedGeneration = { object: null };
+
+    // `null` is a value the schema would reject in a confusing way; it means the same
+    // thing as no answer at all.
+    await expect(parseEmailReply({ question, replyBody, responseSchema: approvalSchema })).rejects.toThrow(
+      'The email parsing agent returned no structured response',
+    );
+  });
+
+  it('lets a failure from the model provider reach the caller', async () => {
+    stagedGeneration = { failure: new Error('503 from the model provider') };
+
+    await expect(parseEmailReply({ question, replyBody, responseSchema: approvalSchema })).rejects.toThrow(
+      '503 from the model provider',
+    );
+  });
+});

--- a/mcp/mastra/verticals/human-in-the-loop/agents.ts
+++ b/mcp/mastra/verticals/human-in-the-loop/agents.ts
@@ -1,3 +1,4 @@
+import type { z } from 'zod';
 import { createAgent } from '../../utils/agent-factory.js';
 
 export async function getEmailParsingAgent() {
@@ -18,8 +19,62 @@ Guidelines:
 - If the user says "no", "reject", "not approved", etc. - interpret as rejection
 - Extract any comments, notes, or additional context provided
 - Be flexible with response formats (bullet points, paragraphs, etc.)
+- The body may still be HTML, and a reply usually quotes the message it answers.
+  Read the person's own words and ignore the markup and the quoted history.
 - If information is missing but can be reasonably inferred, make the inference
 - If information is truly missing and cannot be inferred, use null or empty values`,
     tools: {},
   });
+}
+
+/**
+ * Builds the prompt that turns one email reply into a structured answer.
+ *
+ * Kept separate from {@link parseEmailReply} so its wording can be tested without
+ * reaching a model.
+ */
+export function buildEmailParsingPrompt({ question, replyBody }: { question: string; replyBody: string }): string {
+  return [
+    'A person was asked the following question by email:',
+    '',
+    question,
+    '',
+    'This is their reply, exactly as it arrived:',
+    '',
+    replyBody,
+    '',
+    'Extract their answer into the requested structure.',
+  ].join('\n');
+}
+
+/**
+ * Turns the free text of an email reply into the structured response a suspended
+ * step is waiting for.
+ *
+ * Throws when the model cannot produce something the schema accepts. Callers are
+ * expected to treat that as "this reply did not answer the question" rather than as
+ * a failure of the run: a person who writes "let me think about it" has not answered,
+ * and the request they were sent is still open.
+ */
+export async function parseEmailReply<TResponseSchema extends z.ZodObject<z.ZodRawShape>>({
+  question,
+  replyBody,
+  responseSchema,
+}: {
+  question: string;
+  replyBody: string;
+  responseSchema: TResponseSchema;
+}): Promise<z.output<TResponseSchema>> {
+  const agent = await getEmailParsingAgent();
+
+  const parsed = await agent.generate([{ role: 'user', content: buildEmailParsingPrompt({ question, replyBody }) }], {
+    structuredOutput: { schema: responseSchema },
+    toolChoice: 'none',
+  });
+
+  if (parsed.object === undefined || parsed.object === null) {
+    throw new Error('The email parsing agent returned no structured response');
+  }
+
+  return responseSchema.parse(parsed.object);
 }

--- a/mcp/mastra/verticals/human-in-the-loop/workflows.spec.ts
+++ b/mcp/mastra/verticals/human-in-the-loop/workflows.spec.ts
@@ -1,0 +1,945 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Mastra } from '@mastra/core';
+import { z } from 'zod';
+import { createWorkflow } from '../../utils/workflows/workflow-factory.js';
+import * as realEmailTools from '../email/tools.js';
+import * as realAgents from './agents.js';
+
+/**
+ * The workflow sends real mail through the Microsoft Graph API, so `sendEmail`
+ * is replaced with a recorder. The rest of the email vertical is spread back in
+ * because `mock.module` is process-global in Bun: other spec files sharing this
+ * process (e.g. email/tools.spec.ts, which uses `findEmails`) must still see the
+ * real exports.
+ */
+interface SentEmail {
+  subject: string;
+  bodyContent: string;
+  toRecipients: string[];
+}
+
+const sentEmails: SentEmail[] = [];
+let sendEmailFailure: Error | undefined;
+
+mock.module('../email/tools.js', () => ({
+  ...realEmailTools,
+  // `executeTool` only reaches for `id` and `execute`; the schemas are carried over so
+  // the replacement stays a faithful stand-in for anything else that inspects the tool.
+  sendEmail: {
+    id: 'sendEmail',
+    inputSchema: realEmailTools.sendEmail.inputSchema,
+    outputSchema: realEmailTools.sendEmail.outputSchema,
+    execute: async (inputData: SentEmail) => {
+      sentEmails.push(inputData);
+      if (sendEmailFailure) {
+        throw sendEmailFailure;
+      }
+      return {
+        // What the real tool returns: Graph's sendMail answers 202 with no body, so there
+        // is no message id to report.
+        messageId: 'sent',
+        subject: inputData.subject,
+        success: true,
+        message: 'Email sent successfully',
+      };
+    },
+  },
+}));
+
+/**
+ * Reading a reply is a model call, so the parsing agent is replaced by a recorder that
+ * returns whatever the test has staged. It still validates through the caller's response
+ * schema, so a test cannot stage an answer the real parser could not have produced.
+ *
+ * `mock.module` is process-global, so this stand-in is what every caller in the process
+ * sees -- including `agents.spec.ts`, which tests the real `parseEmailReply` with only the
+ * model underneath it replaced. It therefore answers only while a test in *this* file is
+ * running, and hands the call to the real function outside that window. The real function
+ * is captured before the mock is registered, because registering it rewrites the module
+ * namespace in place.
+ */
+interface ParseRequest {
+  question: string;
+  replyBody: string;
+}
+
+const parseRequests: ParseRequest[] = [];
+let stagedAnswer: unknown;
+let parseFailure: Error | undefined;
+let parserAnswersForThisFile = false;
+const realParseEmailReply = realAgents.parseEmailReply;
+
+mock.module('./agents.js', () => ({
+  ...realAgents,
+  parseEmailReply: async <TResponseSchema extends z.ZodObject<z.ZodRawShape>>(request: {
+    question: string;
+    replyBody: string;
+    responseSchema: TResponseSchema;
+  }) => {
+    if (!parserAnswersForThisFile) {
+      return await realParseEmailReply(request);
+    }
+
+    const { question, replyBody, responseSchema } = request;
+    parseRequests.push({ question, replyBody });
+    if (parseFailure) {
+      throw parseFailure;
+    }
+    return responseSchema.parse(stagedAnswer);
+  },
+}));
+
+const {
+  buildFormRequestSubject,
+  getSendEmailAndAwaitResponseWorkflow,
+  humanInTheLoopDemoWorkflow,
+  parseFormRequestSubject,
+} = await import('./workflows.js');
+
+/** Narrows a workflow result so the status-specific fields are reachable. */
+function assertStatus<TResult extends { status: string }, TStatus extends TResult['status']>(
+  result: TResult,
+  status: TStatus,
+): asserts result is Extract<TResult, { status: TStatus }> {
+  expect(result.status).toBe(status);
+}
+
+const budgetApprovalResponseSchema = z.object({
+  approved: z.boolean(),
+  comments: z.string().optional(),
+});
+
+const awaitBudgetApprovalWorkflow = getSendEmailAndAwaitResponseWorkflow(
+  'budgetApprovalUnderTest',
+  budgetApprovalResponseSchema,
+);
+
+const sendAndWaitMastra = new Mastra({ workflows: { awaitBudgetApprovalWorkflow } });
+
+async function startFormRequest(inputData: { recipientEmail: string; question: string }) {
+  const run = await sendAndWaitMastra.getWorkflow('awaitBudgetApprovalWorkflow').createRun();
+  const started = await run.start({ inputData });
+  return { run, started };
+}
+
+/**
+ * The request id carried by the email at `index` in the outbox.
+ *
+ * A reply is only accepted for the request it quotes, so every resume in these tests takes
+ * the same route a real reply does: read the token back off the email that was sent.
+ */
+function requestIdOf(index: number): string {
+  const email = sentEmails[index];
+  if (!email) {
+    throw new Error(`No email was sent at index ${index}; the outbox holds ${sentEmails.length}.`);
+  }
+
+  const formRequest = parseFormRequestSubject(email.subject);
+  if (!formRequest) {
+    throw new Error(`The subject "${email.subject}" carries no form request token.`);
+  }
+
+  return formRequest.requestId;
+}
+
+beforeEach(() => {
+  sentEmails.length = 0;
+  parseRequests.length = 0;
+  sendEmailFailure = undefined;
+  parseFailure = undefined;
+  stagedAnswer = undefined;
+  parserAnswersForThisFile = true;
+});
+
+afterEach(() => {
+  // Outside this file's tests the recorder steps aside; see the note on the mock.
+  parserAnswersForThisFile = false;
+});
+
+describe('getSendEmailAndAwaitResponseWorkflow', () => {
+  it('names the workflow after the slug it was built with', () => {
+    expect(awaitBudgetApprovalWorkflow.id).toBe('sendEmailAndAwaitResponseWorkflow-budgetApprovalUnderTest');
+  });
+
+  it('consists of exactly the send step and the suspending step', () => {
+    // Still no timeout/expiry step: a suspended request waits until it is answered. The
+    // email no longer claims otherwise.
+    expect(Object.keys(awaitBudgetApprovalWorkflow.steps)).toEqual(['send-form-request-email', 'await-email-response']);
+  });
+
+  describe('sending the form request', () => {
+    it('sends a single email to the recipient with the run id in the subject', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve the budget?' });
+
+      expect(sentEmails).toHaveLength(1);
+      expect(sentEmails[0].toRecipients).toEqual(['boss@example.com']);
+      // The run id, not the workflow id: the workflow id is the same for every run and
+      // every recipient, so it could never say which suspended run a reply answers. The
+      // request id alongside it says which question of that run was asked.
+      expect(sentEmails[0].subject).toBe(
+        buildFormRequestSubject({ runId: run.runId, requestId: requestIdOf(0), question: 'Approve the budget?' }),
+      );
+      expect(parseFormRequestSubject(sentEmails[0].subject)).toEqual({
+        runId: run.runId,
+        requestId: requestIdOf(0),
+      });
+    });
+
+    it('reads its own token back out of a subject a mail client has replied to', () => {
+      const subject = buildFormRequestSubject({ runId: 'run-1', requestId: 'req-1', question: 'Approve?' });
+
+      // The one definition of the token's shape is shared by both sides, so the sweeper
+      // cannot drift away from the format the email actually carries.
+      expect(parseFormRequestSubject(`Re: ${subject}`)).toEqual({ runId: 'run-1', requestId: 'req-1' });
+      expect(parseFormRequestSubject('Re: Lunch?')).toBeUndefined();
+      expect(parseFormRequestSubject('Re: Form Request [RUN-run-1]: Approve?')).toBeUndefined();
+    });
+
+    it('gives two runs of the same workflow different subject tokens', async () => {
+      const first = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+      const second = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      expect(first.run.runId).not.toBe(second.run.runId);
+      expect(sentEmails[0].subject).not.toBe(sentEmails[1].subject);
+    });
+
+    it('builds an HTML body carrying the question, the run id and the reply instructions', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve the budget?' });
+
+      const { bodyContent } = sentEmails[0];
+      expect(bodyContent.startsWith('<html>')).toBe(true);
+      expect(bodyContent.endsWith('</html>')).toBe(true);
+      expect(bodyContent).toContain('<strong>Question:</strong> Approve the budget?');
+      expect(bodyContent).toContain(`Request reference: ${run.runId}/${requestIdOf(0)}`);
+      expect(bodyContent).toContain('Please do not modify the subject line');
+    });
+
+    it('promises no expiry, because nothing expires the request', async () => {
+      await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve the budget?' });
+
+      // The body used to render a date 14 days out and call it an expiry, while the graph
+      // was only send -> await: no step, sweeper or timer ever ended a suspension.
+      expect(sentEmails[0].bodyContent.toLowerCase()).not.toContain('expire');
+    });
+
+    it('rejects a recipient that is not an email address', async () => {
+      const run = await sendAndWaitMastra.getWorkflow('awaitBudgetApprovalWorkflow').createRun();
+
+      await expect(run.start({ inputData: { recipientEmail: 'boss', question: 'Approve?' } })).rejects.toThrow(
+        /recipientEmail: Invalid email address/,
+      );
+      expect(sentEmails).toHaveLength(0);
+    });
+
+    it('fails the run without suspending when the email cannot be sent', async () => {
+      sendEmailFailure = new Error('Failed to send email: 401 Unauthorized');
+
+      const { started } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      assertStatus(started, 'failed');
+      expect(started.error.message).toContain('Failed to send email');
+    });
+  });
+
+  describe('suspending', () => {
+    it('describes the pending request in the suspend payload', async () => {
+      const { started } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      assertStatus(started, 'suspended');
+      expect(started.suspended).toEqual([['await-email-response']]);
+      expect(started.steps['await-email-response'].status).toBe('suspended');
+      // The payload used to be `{}`, which told a resumer nothing about who was asked,
+      // what was asked, or which shape the answer must have.
+      expect(started.suspendPayload).toEqual({
+        'await-email-response': {
+          recipientEmail: 'boss@example.com',
+          question: 'Approve?',
+          // The id a reply has to quote, rather than the message id: Graph reports no
+          // message id for a sent mail, so that field could only ever say 'sent'.
+          requestId: requestIdOf(0),
+          responseSchema: {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object',
+            properties: { approved: { type: 'boolean' }, comments: { type: 'string' } },
+            required: ['approved'],
+            additionalProperties: false,
+          },
+        },
+      });
+    });
+  });
+
+  describe('resuming', () => {
+    it('returns the sender and the typed response when the reply comes from the recipient', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: {
+          requestId: requestIdOf(0),
+          senderEmail: 'boss@example.com',
+          response: { approved: true, comments: 'Looks good' },
+        },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result).toEqual({
+        senderEmail: 'boss@example.com',
+        response: { approved: true, comments: 'Looks good' },
+      });
+      // A caller that already has a structured answer does not pay for a model call.
+      expect(parseRequests).toHaveLength(0);
+    });
+
+    it('reads a free-text reply through the email parsing agent', async () => {
+      stagedAnswer = { approved: true, comments: 'go for it' };
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', replyBody: 'Yeah fine, go for it' },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result.response).toEqual({ approved: true, comments: 'go for it' });
+      // The parser is given the question as context, not just the loose text.
+      expect(parseRequests).toEqual([{ question: 'Approve?', replyBody: 'Yeah fine, go for it' }]);
+    });
+
+    it('compares the sender against the recipient case-insensitively', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'Boss@Example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@EXAMPLE.com', response: { approved: false } },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result.senderEmail).toBe('boss@EXAMPLE.com');
+    });
+
+    it('drops fields the response schema does not declare', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: {
+          requestId: requestIdOf(0),
+          senderEmail: 'boss@example.com',
+          response: { approved: true, injected: 'ignore me' },
+        },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result.response).toEqual({ approved: true });
+    });
+
+    it('refuses a reply from somebody else without accepting it', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'attacker@example.com', response: { approved: true } },
+      });
+
+      assertStatus(resumed, 'suspended');
+      expect(resumed.suspendPayload['await-email-response'].rejectedReply).toEqual({
+        senderEmail: 'attacker@example.com',
+        reason: 'the reply came from attacker@example.com, and the request was sent to boss@example.com',
+      });
+    });
+
+    it('keeps the pending request alive when a reply from the wrong sender arrives first', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+      await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'attacker@example.com', response: { approved: true } },
+      });
+
+      // The security check used to throw, which killed the run: one forwarded or aliased
+      // reply permanently destroyed an approval nobody had answered yet.
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', response: { approved: true } },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result.senderEmail).toBe('boss@example.com');
+    });
+
+    it('refuses an empty sender rather than skipping the security check', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: '', response: { approved: true } },
+      });
+
+      // The guard used to read `if (senderEmail && ...)`, so a falsy sender skipped
+      // validation and the approval was accepted from nobody. An absent address is not
+      // evidence that the right person replied.
+      assertStatus(resumed, 'suspended');
+      expect(resumed.suspendPayload['await-email-response'].rejectedReply).toEqual({
+        senderEmail: '',
+        reason: 'the reply carried no sender address, and the request was sent to boss@example.com',
+      });
+    });
+
+    it('refuses a reply that answers a request other than the one still open', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const refused = await run.resume({
+        step: ['await-email-response'],
+        resumeData: {
+          requestId: 'a-request-this-run-never-asked',
+          senderEmail: 'boss@example.com',
+          response: { approved: true },
+        },
+      });
+
+      // Without this check the run id alone decided which question a reply answered, so a
+      // duplicate or late reply was applied to whichever question happened to be open.
+      assertStatus(refused, 'suspended');
+      expect(refused.suspendPayload['await-email-response'].rejectedReply).toEqual({
+        senderEmail: 'boss@example.com',
+        reason: `the reply answers request a-request-this-run-never-asked, and the question still open is request ${requestIdOf(0)}`,
+      });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', response: { approved: true } },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result.response).toEqual({ approved: true });
+    });
+
+    it('refuses a reply whose body is blank rather than asking the model to read it', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', replyBody: '   \n  ' },
+      });
+
+      // The guard used to be `replyBody === undefined`, so an empty body reached the
+      // parsing agent, which was then free to invent a decision from nothing.
+      assertStatus(resumed, 'suspended');
+      expect(resumed.suspendPayload['await-email-response'].rejectedReply?.reason).toBe(
+        'the resume carried neither a structured response nor a reply body to parse',
+      );
+      expect(parseRequests).toEqual([]);
+    });
+
+    it('refuses a reply the parsing agent cannot read as an answer', async () => {
+      parseFailure = new Error('The email parsing agent returned no structured response');
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const refused = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', replyBody: 'let me think about it' },
+      });
+
+      // An answer nobody gave must not become an answer, and must not cost the request:
+      // the same person can still reply properly afterwards.
+      assertStatus(refused, 'suspended');
+      expect(refused.suspendPayload['await-email-response'].rejectedReply?.reason).toContain(
+        'the reply could not be read as an answer',
+      );
+
+      parseFailure = undefined;
+      stagedAnswer = { approved: true };
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', replyBody: 'Yes, approved' },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result.response).toEqual({ approved: true });
+    });
+
+    it('refuses a resume that carries neither a structured response nor a reply body', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com' },
+      });
+
+      assertStatus(resumed, 'suspended');
+      expect(resumed.suspendPayload['await-email-response'].rejectedReply?.reason).toBe(
+        'the resume carried neither a structured response nor a reply body to parse',
+      );
+    });
+
+    it('rejects a response that does not match the schema', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      await expect(
+        run.resume({
+          step: ['await-email-response'],
+          resumeData: {
+            requestId: requestIdOf(0),
+            senderEmail: 'boss@example.com',
+            response: { approved: 'yes please' },
+          },
+        }),
+      ).rejects.toThrow(/response.approved: Invalid input: expected boolean, received string/);
+
+      // Rejected before the step ran, so the request is untouched and still answerable.
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', response: { approved: true } },
+      });
+      assertStatus(resumed, 'success');
+    });
+
+    it('rejects a resume that carries no data at all', async () => {
+      const { run } = await startFormRequest({ recipientEmail: 'boss@example.com', question: 'Approve?' });
+
+      await expect(run.resume({ step: ['await-email-response'] })).rejects.toThrow(/Invalid resume data/);
+    });
+  });
+
+  describe('per-slug response schemas', () => {
+    const vendorSelectionResponseSchema = z.object({
+      vendorName: z.string(),
+      justification: z.string(),
+    });
+    const awaitVendorSelectionWorkflow = getSendEmailAndAwaitResponseWorkflow(
+      'vendorSelectionUnderTest',
+      vendorSelectionResponseSchema,
+    );
+    const vendorMastra = new Mastra({ workflows: { awaitVendorSelectionWorkflow } });
+
+    it('validates the reply against the schema the workflow was built with', async () => {
+      const run = await vendorMastra.getWorkflow('awaitVendorSelectionWorkflow').createRun();
+      await run.start({ inputData: { recipientEmail: 'boss@example.com', question: 'Which vendor?' } });
+
+      const resumed = await run.resume({
+        step: ['await-email-response'],
+        resumeData: {
+          requestId: requestIdOf(0),
+          senderEmail: 'boss@example.com',
+          response: { vendorName: 'Acme', justification: 'Cheapest bid' },
+        },
+      });
+
+      assertStatus(resumed, 'success');
+      expect(resumed.result.response).toEqual({ vendorName: 'Acme', justification: 'Cheapest bid' });
+    });
+
+    it('advertises its own response shape in the suspend payload', async () => {
+      const run = await vendorMastra.getWorkflow('awaitVendorSelectionWorkflow').createRun();
+      const started = await run.start({ inputData: { recipientEmail: 'boss@example.com', question: 'Which vendor?' } });
+
+      assertStatus(started, 'suspended');
+      expect(started.suspendPayload['await-email-response'].responseSchema).toMatchObject({
+        properties: { vendorName: { type: 'string' }, justification: { type: 'string' } },
+        required: ['vendorName', 'justification'],
+      });
+    });
+
+    it('refuses a reply shaped for a different slug', async () => {
+      const run = await vendorMastra.getWorkflow('awaitVendorSelectionWorkflow').createRun();
+      await run.start({ inputData: { recipientEmail: 'boss@example.com', question: 'Which vendor?' } });
+
+      await expect(
+        run.resume({
+          step: ['await-email-response'],
+          resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', response: { approved: true } },
+        }),
+      ).rejects.toThrow(/vendorName/);
+    });
+  });
+});
+
+describe('humanInTheLoopDemoWorkflow', () => {
+  const demoMastra = new Mastra({ workflows: { humanInTheLoopDemoWorkflow } });
+
+  const budgetApprovalStep = ['sendEmailAndAwaitResponseWorkflow-budgetApproval', 'await-email-response'];
+  const vendorSelectionStep = ['sendEmailAndAwaitResponseWorkflow-vendorSelection', 'await-email-response'];
+  const finalConfirmationStep = ['sendEmailAndAwaitResponseWorkflow-finalConfirmation', 'await-email-response'];
+
+  /**
+   * Mastra types `run.start()` with the *output* of the input schema, so a field carrying
+   * a default still has to be passed. `listWorkflows()` hands back the same instances
+   * under the loosely typed `Workflow` signature, which is how these tests give the
+   * workflow the partial input a caller really would -- defaults included.
+   */
+  const looselyTypedDemoWorkflow = demoMastra.listWorkflows().humanInTheLoopDemoWorkflow;
+
+  async function startDemoRun(inputData: { recipientEmail: string; projectName?: string; budgetAmount?: number }) {
+    const run = await looselyTypedDemoWorkflow.createRun();
+    const started = await run.start({ inputData });
+    return { run, started };
+  }
+
+  it('refuses to run without a recipient instead of mailing a placeholder', async () => {
+    const run = await looselyTypedDemoWorkflow.createRun();
+
+    // `recipientEmail` used to default to demo@example.com, so pressing "run" on this
+    // workflow in Mastra Studio sent real mail to whoever owned that address.
+    await expect(run.start({ inputData: { projectName: 'Atlas' } })).rejects.toThrow(/recipientEmail/);
+    expect(sentEmails).toHaveLength(0);
+  });
+
+  it('still falls back to the demo project and budget', async () => {
+    const { started } = await startDemoRun({ recipientEmail: 'boss@example.com' });
+
+    assertStatus(started, 'suspended');
+    expect(started.input).toEqual({
+      recipientEmail: 'boss@example.com',
+      projectName: 'Demo Project',
+      budgetAmount: 10000,
+    });
+    expect(sentEmails[0].toRecipients).toEqual(['boss@example.com']);
+    expect(sentEmails[0].subject).toContain('Please approve the budget for project "Demo Project". Amount: $10,000.');
+  });
+
+  it('renders the budget with thousands separators in the question', async () => {
+    await startDemoRun({ recipientEmail: 'boss@example.com', projectName: 'Atlas', budgetAmount: 1234567 });
+
+    expect(sentEmails[0].subject).toContain('Please approve the budget for project "Atlas". Amount: $1,234,567.');
+  });
+
+  it('suspends inside the nested budget approval workflow first', async () => {
+    const { started } = await startDemoRun({ recipientEmail: 'boss@example.com' });
+
+    assertStatus(started, 'suspended');
+    expect(started.suspended).toEqual([budgetApprovalStep]);
+    expect(sentEmails).toHaveLength(1);
+  });
+
+  it('gives every stage of one run its own request id under the shared run id', async () => {
+    const { run } = await startDemoRun({ recipientEmail: 'boss@example.com', projectName: 'Atlas' });
+
+    await run.resume({
+      step: budgetApprovalStep,
+      resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', response: { approved: true } },
+    });
+
+    // Every stage suspends under the same run id, which is exactly why the run id alone
+    // cannot say which question a reply answers.
+    const budget = parseFormRequestSubject(sentEmails[0].subject);
+    const vendor = parseFormRequestSubject(sentEmails[1].subject);
+    expect(budget?.runId).toBe(run.runId);
+    expect(vendor?.runId).toBe(run.runId);
+    expect(budget?.requestId).not.toBe(vendor?.requestId);
+  });
+
+  it('walks approval, then vendor selection, then final confirmation, and finishes', async () => {
+    const { run } = await startDemoRun({
+      recipientEmail: 'boss@example.com',
+      projectName: 'Atlas',
+      budgetAmount: 2500,
+    });
+
+    const afterApproval = await run.resume({
+      step: budgetApprovalStep,
+      resumeData: {
+        requestId: requestIdOf(0),
+        senderEmail: 'boss@example.com',
+        response: { approved: true, comments: 'Go ahead' },
+      },
+    });
+
+    assertStatus(afterApproval, 'suspended');
+    expect(afterApproval.suspended).toEqual([vendorSelectionStep]);
+    expect(sentEmails).toHaveLength(2);
+    // The project name survives the nested workflow because the merge step reads it
+    // back from the workflow's init data.
+    expect(sentEmails[1].subject).toContain('Please select a vendor for project "Atlas".');
+
+    const afterVendorSelection = await run.resume({
+      step: vendorSelectionStep,
+      resumeData: {
+        requestId: requestIdOf(1),
+        senderEmail: 'boss@example.com',
+        response: { vendorName: 'Acme', justification: 'Cheapest bid' },
+      },
+    });
+
+    assertStatus(afterVendorSelection, 'suspended');
+    expect(afterVendorSelection.suspended).toEqual([finalConfirmationStep]);
+    expect(sentEmails).toHaveLength(3);
+    expect(sentEmails[2].subject).toContain('Final confirmation for project "Atlas" with vendor "Acme".');
+
+    const afterConfirmation = await run.resume({
+      step: finalConfirmationStep,
+      resumeData: {
+        requestId: requestIdOf(2),
+        senderEmail: 'boss@example.com',
+        response: { confirmed: true, finalNotes: 'Ship it' },
+      },
+    });
+
+    // The last hop used to die: the nested workflow emits only `{ senderEmail, response }`
+    // and nothing put the chosen vendor back on the context, so the demo could never
+    // reach its own final output.
+    assertStatus(afterConfirmation, 'success');
+    expect(afterConfirmation.result).toEqual({
+      success: true,
+      message: 'Workflow completed successfully! Budget approved, vendor "Acme" selected and confirmed.',
+      approvalGranted: true,
+      vendorSelected: 'Acme',
+      finalConfirmation: true,
+    });
+  });
+
+  it('runs end to end on free-text replies alone', async () => {
+    const { run } = await startDemoRun({ recipientEmail: 'boss@example.com', projectName: 'Atlas' });
+
+    stagedAnswer = { approved: true };
+    await run.resume({
+      step: budgetApprovalStep,
+      resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', replyBody: 'Yes, that budget is fine' },
+    });
+
+    stagedAnswer = { vendorName: 'Acme', justification: 'Cheapest bid' };
+    await run.resume({
+      step: vendorSelectionStep,
+      resumeData: {
+        requestId: requestIdOf(1),
+        senderEmail: 'boss@example.com',
+        replyBody: 'Go with Acme, they were cheapest',
+      },
+    });
+
+    stagedAnswer = { confirmed: false, finalNotes: 'Changed my mind' };
+    const finished = await run.resume({
+      step: finalConfirmationStep,
+      resumeData: { requestId: requestIdOf(2), senderEmail: 'boss@example.com', replyBody: 'Actually cancel it' },
+    });
+
+    assertStatus(finished, 'success');
+    expect(finished.result).toEqual({
+      success: true,
+      message: 'Workflow completed. Vendor "Acme" was selected but final confirmation was cancelled.',
+      approvalGranted: true,
+      vendorSelected: 'Acme',
+      finalConfirmation: false,
+    });
+    expect(parseRequests.map((request) => request.replyBody)).toEqual([
+      'Yes, that budget is fine',
+      'Go with Acme, they were cheapest',
+      'Actually cancel it',
+    ]);
+  });
+
+  it('sends the follow-up requests to the address that actually replied', async () => {
+    const { run } = await startDemoRun({ recipientEmail: 'boss@example.com' });
+
+    await run.resume({
+      step: budgetApprovalStep,
+      // Accepted by the case-insensitive check, and from here on it becomes the recipient.
+      resumeData: { requestId: requestIdOf(0), senderEmail: 'BOSS@Example.com', response: { approved: true } },
+    });
+
+    expect(sentEmails[1].toRecipients).toEqual(['BOSS@Example.com']);
+  });
+
+  it('completes with a rejection when the budget is not approved', async () => {
+    const { run } = await startDemoRun({ recipientEmail: 'boss@example.com', projectName: 'Atlas' });
+
+    const afterRejection = await run.resume({
+      step: budgetApprovalStep,
+      resumeData: {
+        requestId: requestIdOf(0),
+        senderEmail: 'boss@example.com',
+        response: { approved: false, comments: 'Too expensive' },
+      },
+    });
+
+    // "No" is one of the two answers the question invites, and the output schema models
+    // it. The run used to fail with "Budget was not approved - workflow cannot continue".
+    assertStatus(afterRejection, 'success');
+    expect(afterRejection.result).toEqual({
+      success: true,
+      message: 'Workflow completed. The budget for project "Atlas" was not approved: Too expensive',
+      approvalGranted: false,
+    });
+    expect(sentEmails).toHaveLength(1);
+  });
+
+  it('reports a rejection without comments too', async () => {
+    const { run } = await startDemoRun({ recipientEmail: 'boss@example.com', projectName: 'Atlas' });
+
+    const afterRejection = await run.resume({
+      step: budgetApprovalStep,
+      resumeData: { requestId: requestIdOf(0), senderEmail: 'boss@example.com', response: { approved: false } },
+    });
+
+    assertStatus(afterRejection, 'success');
+    expect(afterRejection.result).toEqual({
+      success: true,
+      message: 'Workflow completed. The budget for project "Atlas" was not approved.',
+      approvalGranted: false,
+    });
+  });
+
+  it('stops an empty sender at the security check and keeps waiting', async () => {
+    const { run } = await startDemoRun({ recipientEmail: 'boss@example.com' });
+
+    const afterApproval = await run.resume({
+      step: budgetApprovalStep,
+      resumeData: { requestId: requestIdOf(0), senderEmail: '', response: { approved: true } },
+    });
+
+    // Previously the approval was accepted and the run limped on, only dying once the
+    // empty address was reused as the next recipient -- reported as
+    // "recipientEmail: Invalid email address", which says nothing about the real problem.
+    assertStatus(afterApproval, 'suspended');
+    expect(afterApproval.suspended).toEqual([budgetApprovalStep]);
+    expect(sentEmails).toHaveLength(1);
+  });
+});
+
+describe('demo workflow steps in isolation', () => {
+  /**
+   * Steps are private to the module, but the committed workflow exposes them, so a step
+   * is driven directly through a one-step harness when the interesting input is easier to
+   * hand it than to reach through the graph.
+   */
+  async function runStepInIsolation<TInputSchema extends z.ZodTypeAny, TOutputSchema extends z.ZodTypeAny>(
+    stepId: string,
+    schemas: { inputSchema: TInputSchema; outputSchema: TOutputSchema },
+    inputData: z.input<TInputSchema>,
+  ): Promise<z.infer<TOutputSchema>> {
+    const harness = createWorkflow({
+      id: `isolated-${stepId}`,
+      inputSchema: schemas.inputSchema,
+      outputSchema: schemas.outputSchema,
+    })
+      .then(humanInTheLoopDemoWorkflow.steps[stepId])
+      .commit();
+
+    const mastra = new Mastra({ workflows: { harness } });
+    const run = await mastra.listWorkflows().harness.createRun();
+    const result = await run.start({ inputData });
+
+    assertStatus(result, 'success');
+    return schemas.outputSchema.parse(result.result);
+  }
+
+  const finalConfirmationInputSchema = z.object({
+    confirmed: z.boolean(),
+    finalNotes: z.string().optional(),
+    vendorName: z.string(),
+  });
+
+  const finalOutputSchema = z.object({
+    success: z.boolean(),
+    message: z.string(),
+    approvalGranted: z.boolean().optional(),
+    vendorSelected: z.string().optional(),
+    finalConfirmation: z.boolean().optional(),
+  });
+
+  const budgetApprovalContextSchema = z.object({
+    approved: z.boolean(),
+    comments: z.string().optional(),
+    recipientEmail: z.string(),
+    projectName: z.string(),
+  });
+
+  it('reports a fully confirmed run as successful', async () => {
+    const output = await runStepInIsolation(
+      'format-final-output',
+      { inputSchema: finalConfirmationInputSchema, outputSchema: finalOutputSchema },
+      { confirmed: true, finalNotes: 'Ship it', vendorName: 'Acme' },
+    );
+
+    expect(output).toEqual({
+      success: true,
+      message: 'Workflow completed successfully! Budget approved, vendor "Acme" selected and confirmed.',
+      approvalGranted: true,
+      vendorSelected: 'Acme',
+      finalConfirmation: true,
+    });
+  });
+
+  it('reports a cancelled confirmation as a successful run with finalConfirmation false', async () => {
+    const output = await runStepInIsolation(
+      'format-final-output',
+      { inputSchema: finalConfirmationInputSchema, outputSchema: finalOutputSchema },
+      { confirmed: false, vendorName: 'Acme' },
+    );
+
+    expect(output).toEqual({
+      success: true,
+      message: 'Workflow completed. Vendor "Acme" was selected but final confirmation was cancelled.',
+      approvalGranted: true,
+      vendorSelected: 'Acme',
+      finalConfirmation: false,
+    });
+  });
+
+  it('extracts the final confirmation once the vendor name is supplied', async () => {
+    const output = await runStepInIsolation(
+      'extract-final-confirmation-response',
+      {
+        inputSchema: z.object({
+          senderEmail: z.string(),
+          response: z.object({ confirmed: z.boolean(), finalNotes: z.string().optional() }),
+          vendorName: z.string(),
+        }),
+        outputSchema: finalConfirmationInputSchema,
+      },
+      {
+        senderEmail: 'boss@example.com',
+        response: { confirmed: true, finalNotes: 'Ship it' },
+        vendorName: 'Acme',
+      },
+    );
+
+    expect(output).toEqual({ confirmed: true, finalNotes: 'Ship it', vendorName: 'Acme' });
+  });
+
+  it('reuses the replying address as the recipient for the next request', async () => {
+    const output = await runStepInIsolation(
+      'extract-budget-approval-response',
+      {
+        inputSchema: z.object({
+          senderEmail: z.string(),
+          response: z.object({ approved: z.boolean(), comments: z.string().optional() }),
+        }),
+        outputSchema: z.object({
+          approved: z.boolean(),
+          comments: z.string().optional(),
+          recipientEmail: z.string(),
+        }),
+      },
+      { senderEmail: 'boss@example.com', response: { approved: true, comments: 'Fine' } },
+    );
+
+    expect(output).toEqual({ approved: true, comments: 'Fine', recipientEmail: 'boss@example.com' });
+  });
+
+  it('passes an approved budget straight through the rejection gate', async () => {
+    const output = await runStepInIsolation(
+      'stop-when-budget-is-rejected',
+      { inputSchema: budgetApprovalContextSchema, outputSchema: budgetApprovalContextSchema },
+      { approved: true, comments: 'Fine', recipientEmail: 'boss@example.com', projectName: 'Atlas' },
+    );
+
+    expect(output).toEqual({
+      approved: true,
+      comments: 'Fine',
+      recipientEmail: 'boss@example.com',
+      projectName: 'Atlas',
+    });
+  });
+});
+
+describe('human-in-the-loop vertical exports', () => {
+  it('re-exports the agent, the tools and both workflows', async () => {
+    const vertical = await import('./index.js');
+
+    expect(typeof vertical.getEmailParsingAgent).toBe('function');
+    expect(typeof vertical.getSendEmailAndAwaitResponseWorkflow).toBe('function');
+    expect(vertical.humanInTheLoopDemoWorkflow.id).toBe('humanInTheLoopDemoWorkflow');
+    // The vertical ships no tools yet; the export exists so the registry can spread it.
+    expect(vertical.humanInTheLoopTools).toEqual({});
+  });
+});

--- a/mcp/mastra/verticals/human-in-the-loop/workflows.ts
+++ b/mcp/mastra/verticals/human-in-the-loop/workflows.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { executeTool } from '../../utils/tool-factory.js';
 import { createStep, createWorkflow } from '../../utils/workflows/workflow-factory.js';
 import { sendEmail } from '../email/tools.js';
+import { parseEmailReply } from './agents.js';
 
 /**
  * Send Email and Await Response Workflow
@@ -22,27 +23,94 @@ const sendAndWaitInputSchema = z.object({
   question: z.string().describe('Question to ask in the email'),
 });
 
-// Intermediate schema for email sending step output
+// Intermediate schema for email sending step output.
+//
+// There is no `messageId`: Graph's sendMail answers 202 with no body, so the tool has
+// nothing to report but the literal string 'sent', and a constant cannot correlate
+// anything. `requestId` is the handle that can -- it is minted here and quoted by the
+// reply that answers this exact email.
 const emailSentSchema = z.object({
-  messageId: z.string(),
+  requestId: z.string(),
   subject: z.string(),
   success: z.boolean(),
   message: z.string(),
   recipientEmail: z.string(),
+  question: z.string(),
 });
+
+/**
+ * Builds the subject token that lets an inbound reply be matched back to the exact
+ * question it answers.
+ *
+ * Two identifiers, because neither is enough alone:
+ *
+ * - The run id says *which suspended run* the reply belongs to. Not the workflow id: that
+ *   is a constant shared by every run and every recipient, which is why the reply handler
+ *   used to parse it back out and then give up. The run id seen by a step inside a nested
+ *   workflow is the id of the top-level run, so it is exactly what
+ *   `Workflow.getWorkflowRunById()` needs on the way back in.
+ * - The request id says *which question of that run* was asked. A run that asks three
+ *   questions in sequence suspends three times under the same run id, so a run id on its
+ *   own matches a reply to whichever question happens to be open now -- which meant a
+ *   duplicate reply to question one was recorded as the answer to question two.
+ *
+ * Both halves are checked at resume time, so a reply can only ever answer the request it
+ * was sent for.
+ */
+export function buildFormRequestSubject({
+  runId,
+  requestId,
+  question,
+}: {
+  runId: string;
+  requestId: string;
+  question: string;
+}): string {
+  return `Form Request [RUN-${runId}/REQ-${requestId}]: ${question}`;
+}
+
+/**
+ * Matches the token {@link buildFormRequestSubject} writes, in a subject that has usually
+ * had "Re: " prefixed to it by the replying mail client.
+ */
+const FORM_REQUEST_SUBJECT_REGEX = /\[RUN-([^\]\s/]+)\/REQ-([^\]\s/]+)\]/;
+
+/**
+ * Reads the run and request ids back out of a reply's subject.
+ *
+ * One definition of the token's shape, shared by the side that writes it and the side
+ * that reads it, so the two cannot drift apart.
+ *
+ * @returns Both ids, or `undefined` when the subject carries no complete token -- which
+ * is the case for ordinary mail, and for anything whose token was mangled in transit.
+ */
+export function parseFormRequestSubject(subject: string): { runId: string; requestId: string } | undefined {
+  const match = subject.match(FORM_REQUEST_SUBJECT_REGEX);
+  if (!match) {
+    return undefined;
+  }
+
+  return { runId: match[1], requestId: match[2] };
+}
 
 // Step 1: Send email with form request (static, not dependent on response schema)
 const sendFormRequestEmail = createStep({
   id: 'send-form-request-email',
-  description: 'Send email with embedded workflow ID',
+  description: 'Send email carrying the run and request ids that identify this question',
   inputSchema: sendAndWaitInputSchema,
   outputSchema: emailSentSchema,
   execute: async (params) => {
     const { recipientEmail, question } = params.inputData;
-    const timeoutDate = new Date();
-    timeoutDate.setDate(timeoutDate.getDate() + 14);
 
-    const subject = `Form Request [WF-${params.workflowId}]: ${question}`;
+    // A fresh id per request, minted here rather than derived from the run: every
+    // send-and-wait stage of a parent workflow shares the parent's run id, so this is
+    // the only thing that tells one stage's email apart from the next one's.
+    const requestId = crypto.randomUUID();
+
+    // No expiry is advertised, because nothing expires the suspension: the graph is
+    // send -> await, and a suspended run waits until it is resumed or deleted. The email
+    // used to promise a 14-day deadline that no code enforced.
+    const subject = buildFormRequestSubject({ runId: params.runId, requestId, question });
     const bodyContent = `
 <html>
   <body>
@@ -50,8 +118,7 @@ const sendFormRequestEmail = createStep({
     <p><strong>Question:</strong> ${question}</p>
     <p>Please reply to this email with your answer. Your response will be processed automatically.</p>
     <hr>
-    <p><small>Workflow ID: ${params.workflowId}</small></p>
-    <p><small>This request expires on: ${timeoutDate.toLocaleString()}</small></p>
+    <p><small>Request reference: ${params.runId}/${requestId}</small></p>
     <p><small>Please do not modify the subject line - it contains important tracking information.</small></p>
   </body>
 </html>
@@ -64,18 +131,90 @@ const sendFormRequestEmail = createStep({
     });
 
     return {
-      messageId: emailResult.messageId,
+      requestId,
       subject: emailResult.subject,
       success: emailResult.success,
       message: emailResult.message,
       recipientEmail,
+      question,
     };
   },
 });
 
 /**
+ * What a suspended request tells whoever finds it.
+ *
+ * The payload used to be `{}`, which left a resumer with no way to know whose reply the
+ * run was waiting for, which request it was waiting on, what it had asked, or what an
+ * acceptable answer looks like. All four are needed: the address to match an inbound
+ * sender against, the id an answering reply has to quote, the question to give a parser
+ * context, and the shape the answer has to take.
+ */
+const pendingEmailRequestSchema = z.object({
+  recipientEmail: z.string().describe('The only address whose reply will be accepted'),
+  question: z.string().describe('The question that was asked'),
+  requestId: z.string().describe('Id of this request; only a reply quoting it will be accepted'),
+  responseSchema: z.record(z.string(), z.unknown()).describe('JSON Schema of the answer this step accepts'),
+  rejectedReply: z
+    .object({
+      senderEmail: z.string().describe('Address the refused reply came from'),
+      reason: z.string().describe('Why the reply was not accepted'),
+    })
+    .optional()
+    .describe('Set when a reply arrived and was refused; the request is still open'),
+});
+
+/**
+ * Decides whether a reply may be treated as coming from the person who was asked.
+ *
+ * Fails closed in both directions: an empty sender is refused rather than skipped (the
+ * guard used to read `senderEmail && ...`, so a falsy sender disabled the check and an
+ * approval was accepted from nobody), and a request that records no recipient can verify
+ * nothing, so it refuses too.
+ */
+function describeSenderProblem(senderEmail: string, recipientEmail: string): string | undefined {
+  if (!recipientEmail) {
+    return 'the request records no expected recipient, so no reply can be verified against it';
+  }
+
+  if (!senderEmail) {
+    return `the reply carried no sender address, and the request was sent to ${recipientEmail}`;
+  }
+
+  if (senderEmail.toLowerCase() !== recipientEmail.toLowerCase()) {
+    return `the reply came from ${senderEmail}, and the request was sent to ${recipientEmail}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Decides whether a reply may be treated as an answer to the question that is still open.
+ *
+ * The reply quotes the request id of the email it answers; the step knows the id of the
+ * request it is suspended on. Anything else -- a duplicate reply to a question already
+ * answered, or a late reply to stage one arriving while stage two waits -- names a
+ * request that is no longer open, and answering the wrong question with it records a
+ * decision nobody made.
+ */
+function describeStaleReplyProblem(quotedRequestId: string, requestId: string): string | undefined {
+  if (quotedRequestId === requestId) {
+    return undefined;
+  }
+
+  return `the reply answers request ${quotedRequestId}, and the question still open is request ${requestId}`;
+}
+
+/**
  * Creates the await email response step with a typed response schema.
  * This is a factory function that generates a step with the correct output types.
+ *
+ * A reply that cannot be accepted -- one answering a request that is no longer open,
+ * a wrong or missing sender, or text the parsing agent cannot turn into the expected
+ * answer -- suspends the step again instead of throwing.
+ * Throwing killed the run, and with it the pending request: a single forwarded or
+ * aliased reply permanently destroyed an approval nobody had answered yet. Re-suspending
+ * refuses the reply and leaves the question open for the person who was actually asked.
  */
 function createAwaitEmailResponseStep<TResponseSchema extends z.ZodObject<z.ZodRawShape>>(
   responseSchema: TResponseSchema,
@@ -85,33 +224,70 @@ function createAwaitEmailResponseStep<TResponseSchema extends z.ZodObject<z.ZodR
     response: responseSchema,
   });
 
+  const resumeSchema = z.object({
+    requestId: z.string().describe('Id of the request being answered, taken from the subject of the reply'),
+    senderEmail: z.string().describe('Email of the person who responded'),
+    replyBody: z.string().optional().describe('Raw text of the reply, to be parsed by the email parsing agent'),
+    response: responseSchema.optional().describe('An already structured answer, when the caller parsed it itself'),
+  });
+
+  // Fixed the moment the step is created, so it is built once per step rather than once
+  // per run and once more on every re-suspension.
+  const responseJsonSchema = z.toJSONSchema(responseSchema);
+
   return createStep({
     id: 'await-email-response',
     description: 'Suspend workflow and wait for email response',
     inputSchema: emailSentSchema,
     outputSchema,
-    resumeSchema: outputSchema,
-    suspendSchema: z.object({}),
+    resumeSchema,
+    suspendSchema: pendingEmailRequestSchema,
     execute: async ({ inputData, resumeData, suspend }) => {
-      const { recipientEmail } = inputData;
+      const { recipientEmail, question, requestId } = inputData;
+      const pendingRequest = {
+        recipientEmail,
+        question,
+        requestId,
+        responseSchema: responseJsonSchema,
+      };
 
-      // If we have resume data, process it and return
-      if (resumeData) {
-        const parsed = outputSchema.parse(resumeData);
-        const { senderEmail } = parsed;
-
-        // Validate sender email
-        if (senderEmail && recipientEmail && senderEmail.toLowerCase() !== recipientEmail.toLowerCase()) {
-          throw new Error(
-            `Security validation failed: Email sender ${senderEmail} does not match expected recipient ${recipientEmail}`,
-          );
-        }
-
-        return parsed;
+      if (!resumeData) {
+        return await suspend(pendingRequest);
       }
 
-      // Suspend workflow - will be resumed by checkForFormRepliesWorkflow
-      return await suspend({});
+      const { requestId: quotedRequestId, senderEmail, replyBody, response } = resumeData;
+
+      const staleReplyProblem = describeStaleReplyProblem(quotedRequestId, requestId);
+      if (staleReplyProblem) {
+        console.warn(`🚫 Refusing a reply to "${question}": ${staleReplyProblem}`);
+        return await suspend({ ...pendingRequest, rejectedReply: { senderEmail, reason: staleReplyProblem } });
+      }
+
+      const senderProblem = describeSenderProblem(senderEmail, recipientEmail);
+      if (senderProblem) {
+        console.warn(`🚫 Refusing a reply to "${question}": ${senderProblem}`);
+        return await suspend({ ...pendingRequest, rejectedReply: { senderEmail, reason: senderProblem } });
+      }
+
+      if (response !== undefined) {
+        return { senderEmail, response };
+      }
+
+      // Blankness, not absence: an empty body and a missing one are the same non-answer,
+      // and handing the model an empty string only invites it to invent a decision.
+      if (!replyBody?.trim()) {
+        const reason = 'the resume carried neither a structured response nor a reply body to parse';
+        console.warn(`🚫 Refusing a reply to "${question}": ${reason}`);
+        return await suspend({ ...pendingRequest, rejectedReply: { senderEmail, reason } });
+      }
+
+      try {
+        return { senderEmail, response: await parseEmailReply({ question, replyBody, responseSchema }) };
+      } catch (error) {
+        const reason = `the reply could not be read as an answer: ${error instanceof Error ? error.message : String(error)}`;
+        console.warn(`🚫 Refusing a reply to "${question}": ${reason}`);
+        return await suspend({ ...pendingRequest, rejectedReply: { senderEmail, reason } });
+      }
     },
   });
 }
@@ -168,27 +344,32 @@ export function getSendEmailAndAwaitResponseWorkflow<TResponseSchema extends z.Z
  * 2. If approved, request vendor selection (Vendor name + justification)
  * 3. If vendor selected, request final confirmation (Confirm/Cancel)
  *
+ * A rejected budget is an outcome rather than an error: the run finishes with
+ * `approvalGranted: false` and the remaining questions are never asked.
+ *
  * Each step uses the reusable sendEmailAndAwaitResponseWorkflow:
  * - Sends an email with a form request
  * - Suspends the workflow waiting for reply
- * - Validates the email reply contains the correct workflow ID
- * - Parses the response using LLM
- * - Resumes with parsed data
+ * - Validates the reply came from the address that was asked
+ * - Parses the reply with the email parsing agent
+ * - Resumes with the parsed answer
  *
  * Security:
- * - Workflow ID embedded in email subject: [WF-{id}]
- * - Expected sender email validated before resume
- * - 14-day timeout for each response
+ * - Run id and per-request id embedded in the email subject: [RUN-{runId}/REQ-{requestId}]
+ * - A reply is only accepted for the request it quotes, so a duplicate or late reply
+ *   cannot be recorded as the answer to whichever question is open now
+ * - Expected sender validated before an answer is accepted
+ * - A reply that fails validation is refused and the request stays open
  */
 
-// Input schema for the workflow - all fields optional with defaults
+// Input schema for the workflow.
+//
+// `recipientEmail` deliberately has no default. It used to fall back to a placeholder
+// address, which meant pressing "run" on this workflow in Mastra Studio sent real mail
+// through the Graph API to whoever that address belonged to. Requiring it turns a stray
+// run into a validation error instead of an email.
 const workflowInputSchema = z.object({
-  recipientEmail: z
-    .string()
-    .email()
-    .optional()
-    .default('demo@example.com')
-    .describe('Email address to send form requests to'),
+  recipientEmail: z.string().email().describe('Email address to send form requests to'),
   projectName: z.string().optional().default('Demo Project').describe('Name of the project requiring approval'),
   budgetAmount: z.number().optional().default(10000).describe('Budget amount in USD'),
 });
@@ -284,6 +465,13 @@ const extractBudgetApprovalResponse = createStep({
   },
 });
 
+const budgetApprovalContextSchema = z.object({
+  approved: z.boolean(),
+  comments: z.string().optional(),
+  recipientEmail: z.string(),
+  projectName: z.string(),
+});
+
 // Step: Merge budget approval with project context
 const mergeBudgetApprovalContext = createStep({
   id: 'merge-budget-approval-context',
@@ -293,12 +481,7 @@ const mergeBudgetApprovalContext = createStep({
     comments: z.string().optional(),
     recipientEmail: z.string(),
   }),
-  outputSchema: z.object({
-    approved: z.boolean(),
-    comments: z.string().optional(),
-    recipientEmail: z.string(),
-    projectName: z.string(),
-  }),
+  outputSchema: budgetApprovalContextSchema,
   execute: async (params) => {
     const initData = params.getInitData<{ projectName: string; budgetAmount: number }>();
     return {
@@ -310,27 +493,48 @@ const mergeBudgetApprovalContext = createStep({
   },
 });
 
+/**
+ * Step: Finish the run early when the budget was rejected.
+ *
+ * "No" is one of the two answers the question invites, and the output schema already
+ * models it through `approvalGranted`. This used to throw
+ * "Budget was not approved - workflow cannot continue", reporting an ordinary decision
+ * as a failed run.
+ */
+const stopWhenBudgetIsRejected = createStep({
+  id: 'stop-when-budget-is-rejected',
+  description: 'Finish the run with a rejection result when the budget was not approved',
+  inputSchema: budgetApprovalContextSchema,
+  outputSchema: budgetApprovalContextSchema,
+  execute: async (params) => {
+    const { approved, comments, projectName } = params.inputData;
+
+    if (approved) {
+      return params.inputData;
+    }
+
+    return params.bail<z.infer<typeof workflowOutputSchema>>({
+      success: true,
+      message: comments
+        ? `Workflow completed. The budget for project "${projectName}" was not approved: ${comments}`
+        : `Workflow completed. The budget for project "${projectName}" was not approved.`,
+      approvalGranted: false,
+    });
+  },
+});
+
 // Step: Prepare vendor selection question
 const prepareVendorSelectionQuestion = createStep({
   id: 'prepare-vendor-selection-question',
   description: 'Prepare vendor selection question',
-  inputSchema: z.object({
-    approved: z.boolean(),
-    comments: z.string().optional(),
-    recipientEmail: z.string(),
-    projectName: z.string(),
-  }),
+  inputSchema: budgetApprovalContextSchema,
   outputSchema: z.object({
     recipientEmail: z.string(),
     question: z.string(),
     projectName: z.string(),
   }),
   execute: async (params) => {
-    const { approved, recipientEmail, projectName } = params.inputData;
-
-    if (!approved) {
-      throw new Error('Budget was not approved - workflow cannot continue');
-    }
+    const { recipientEmail, projectName } = params.inputData;
 
     return {
       recipientEmail,
@@ -414,6 +618,35 @@ const prepareFinalConfirmationQuestion = createStep({
   },
 });
 
+/**
+ * Step: Put the selected vendor back on the context after the nested workflow.
+ *
+ * The budget and vendor stages each have a merge step for the same reason: a nested
+ * send-and-wait workflow emits only `{ senderEmail, response }`, so everything the
+ * surrounding graph knew is gone by the time the answer comes back. This stage had none,
+ * and `extract-final-confirmation-response` demanded a `vendorName` nothing could supply,
+ * so every run of the demo died on its last hop. The vendor is not workflow input, so
+ * unlike the other two merges it is read back from the step that chose it rather than
+ * from `getInitData()`.
+ */
+const mergeFinalConfirmationContext = createStep({
+  id: 'merge-final-confirmation-context',
+  description: 'Add the selected vendor back to context after workflow',
+  inputSchema: z.object({
+    senderEmail: z.string(),
+    response: finalConfirmationResponseSchema,
+  }),
+  outputSchema: z.object({
+    senderEmail: z.string(),
+    response: finalConfirmationResponseSchema,
+    vendorName: z.string(),
+  }),
+  execute: async (params) => ({
+    ...params.inputData,
+    vendorName: params.getStepResult(prepareFinalConfirmationQuestion).vendorName,
+  }),
+});
+
 // Step: Extract final confirmation response
 const extractFinalConfirmationResponse = createStep({
   id: 'extract-final-confirmation-response',
@@ -421,7 +654,7 @@ const extractFinalConfirmationResponse = createStep({
   inputSchema: z.object({
     senderEmail: z.string(),
     response: finalConfirmationResponseSchema,
-    vendorName: z.string(), // Passed through from prepareFinalConfirmationQuestion step output
+    vendorName: z.string(), // Put back by merge-final-confirmation-context
   }),
   outputSchema: z.object({
     confirmed: z.boolean(),
@@ -484,12 +717,14 @@ export const humanInTheLoopDemoWorkflow = createWorkflow({
   .then(getSendEmailAndAwaitResponseWorkflow('budgetApproval', budgetApprovalResponseSchema)) // Send email and wait for human response
   .then(extractBudgetApprovalResponse)
   .then(mergeBudgetApprovalContext)
+  .then(stopWhenBudgetIsRejected)
   .then(prepareVendorSelectionQuestion)
   .then(getSendEmailAndAwaitResponseWorkflow('vendorSelection', vendorSelectionResponseSchema))
   .then(extractVendorSelectionResponse)
   .then(mergeVendorSelectionContext)
   .then(prepareFinalConfirmationQuestion)
   .then(getSendEmailAndAwaitResponseWorkflow('finalConfirmation', finalConfirmationResponseSchema))
+  .then(mergeFinalConfirmationContext)
   .then(extractFinalConfirmationResponse)
   .then(formatFinalOutput)
   .commit();

--- a/mcp/mastra/verticals/internet-of-things/tools.spec.ts
+++ b/mcp/mastra/verticals/internet-of-things/tools.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { fetchHistoricalStates, getAllDevices, getAllServices } from './tools';
 
 // These tests require a Cloudflared tunnel URL in HEY_JARVIS_HOME_ASSISTANT_URL
@@ -7,7 +8,7 @@ import { fetchHistoricalStates, getAllDevices, getAllServices } from './tools';
 describe('IoT Tools Integration Tests', () => {
   describe('getAllDevices', () => {
     it('should retrieve all devices from Home Assistant', async () => {
-      const result = await getAllDevices.execute({});
+      const result = await executeTool(getAllDevices, {});
 
       // Validate structure
       expect(result).toBeDefined();
@@ -20,7 +21,7 @@ describe('IoT Tools Integration Tests', () => {
 
   describe('getAllServices', () => {
     it('should retrieve all services from Home Assistant', async () => {
-      const result = await getAllServices.execute({});
+      const result = await executeTool(getAllServices, {});
 
       // Validate structure
       expect(result).toBeDefined();
@@ -38,12 +39,12 @@ describe('IoT Tools Integration Tests', () => {
     let entityId: string;
 
     beforeAll(async () => {
-      const devicesResult = await getAllDevices.execute({});
+      const devicesResult = await executeTool(getAllDevices, {});
       expect(devicesResult.devices.length).toBeGreaterThan(0);
 
       const firstDevice = devicesResult.devices[0];
-      expect(firstDevice.entities?.length).toBeGreaterThan(0);
-      entityId = firstDevice.entities![0].id;
+      expect(firstDevice.entities.length).toBeGreaterThan(0);
+      entityId = firstDevice.entities[0].id;
     }, 30000);
 
     it('should fetch historical states with explicit time range', async () => {

--- a/mcp/mastra/verticals/notification/tools.spec.ts
+++ b/mcp/mastra/verticals/notification/tools.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { notifyDevice } from './tools';
 
 describe('Notification Tools Integration Tests', () => {
   describe('notifyDevice', () => {
     it('should handle missing Home Assistant configuration gracefully', async () => {
-      const result = await notifyDevice.execute({
+      const result = await executeTool(notifyDevice, {
         message: 'Test notification',
         conversationTimeout: 5000,
       });
@@ -25,7 +26,7 @@ describe('Notification Tools Integration Tests', () => {
     }, 10000);
 
     it('should validate input schema', async () => {
-      const result = await notifyDevice.execute({
+      const result = await executeTool(notifyDevice, {
         message: 'Test with device name',
         deviceName: 'test_device',
         conversationTimeout: 3000,

--- a/mcp/mastra/verticals/phone/tools.spec.ts
+++ b/mcp/mastra/verticals/phone/tools.spec.ts
@@ -1,16 +1,43 @@
 import { describe, expect, it } from 'bun:test';
+import type { StandardSchemaWithJSON } from '@mastra/core/schema';
 import { sendTextMessage } from './tools';
+
+const { inputSchema, outputSchema } = sendTextMessage;
+
+// Without both schemas every assertion below would be vacuous, so fail loudly.
+if (!inputSchema || !outputSchema) {
+  throw new Error('sendTextMessage must declare both an input and an output schema');
+}
+
+/**
+ * Validates a value against a tool schema, throwing when it does not conform.
+ *
+ * Mastra exposes tool schemas through the Standard Schema interface, whose
+ * `validate` reports failures in its return value rather than throwing. These
+ * tests assert on rejection, so failures are turned back into exceptions.
+ */
+function parseWithSchema<TInput, TOutput>(schema: StandardSchemaWithJSON<TInput, TOutput>, value: unknown): TOutput {
+  const result = schema['~standard'].validate(value);
+
+  if (result instanceof Promise) {
+    throw new Error('Schema validated asynchronously, so its result cannot be asserted on synchronously');
+  }
+
+  if (result.issues) {
+    throw new Error(result.issues.map((issue) => issue.message).join('; '));
+  }
+
+  return result.value;
+}
 
 // These tests exercise the sendTextMessage input contract only — they make no
 // Twilio calls, so they need no credentials and send no SMS. Sending a real
 // message from CI is not viable: Twilio rejects any placeholder number with
 // error 21211, and a genuine number would be texted on every single run.
 describe('Phone Tools', () => {
-  const inputSchema = sendTextMessage.inputSchema;
-
   describe('sendTextMessage input schema', () => {
     it('accepts an E.164 number with a message', () => {
-      const parsed = inputSchema.parse({
+      const parsed = parseWithSchema(inputSchema, {
         phoneNumber: '+15551234567',
         message: 'Test message',
       });
@@ -20,19 +47,19 @@ describe('Phone Tools', () => {
     });
 
     it('rejects input with no phone number', () => {
-      expect(() => inputSchema.parse({ message: 'Test message' })).toThrow();
+      expect(() => parseWithSchema(inputSchema, { message: 'Test message' })).toThrow();
     });
 
     it('rejects input with no message', () => {
-      expect(() => inputSchema.parse({ phoneNumber: '+15551234567' })).toThrow();
+      expect(() => parseWithSchema(inputSchema, { phoneNumber: '+15551234567' })).toThrow();
     });
 
     it('rejects a non-string phone number', () => {
-      expect(() => inputSchema.parse({ phoneNumber: 15551234567, message: 'Test message' })).toThrow();
+      expect(() => parseWithSchema(inputSchema, { phoneNumber: 15551234567, message: 'Test message' })).toThrow();
     });
 
     it('rejects a non-string message', () => {
-      expect(() => inputSchema.parse({ phoneNumber: '+15551234567', message: 42 })).toThrow();
+      expect(() => parseWithSchema(inputSchema, { phoneNumber: '+15551234567', message: 42 })).toThrow();
     });
   });
 
@@ -42,7 +69,7 @@ describe('Phone Tools', () => {
     });
 
     it('declares the result shape callers depend on', () => {
-      const parsed = sendTextMessage.outputSchema.parse({
+      const parsed = parseWithSchema(outputSchema, {
         success: true,
         message: 'Text message sent successfully to +15551234567',
         messageSid: 'SM00000000000000000000000000000000',
@@ -53,7 +80,7 @@ describe('Phone Tools', () => {
     });
 
     it('treats messageSid as optional, since a failed send has none', () => {
-      const parsed = sendTextMessage.outputSchema.parse({
+      const parsed = parseWithSchema(outputSchema, {
         success: false,
         message: 'Could not send',
       });

--- a/mcp/mastra/verticals/routing/workflows.llm-eval.spec.ts
+++ b/mcp/mastra/verticals/routing/workflows.llm-eval.spec.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { Agent } from '@mastra/core/agent';
 import { generateObject } from 'ai';
@@ -87,7 +88,7 @@ Respond with:
 - "reasoning" (string): Clear explanation with specific examples from the DAG`,
   });
 
-  return result.object as EvaluationResult;
+  return result.object;
 }
 
 /**

--- a/mcp/mastra/verticals/routing/workflows.spec.ts
+++ b/mcp/mastra/verticals/routing/workflows.spec.ts
@@ -1,7 +1,9 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, mock } from 'bun:test';
 import type { Agent } from '@mastra/core/agent';
 import { z } from 'zod';
 import {
   type AgentProvider,
+  dagSchema,
   getCurrentDAG,
   getCurrentDagWorkflow,
   getNextInstructionsWorkflow,
@@ -23,14 +25,14 @@ interface MockAgent {
   name: string;
   getDescription(): string;
   listTools(): Promise<Record<string, unknown>>;
-  generate: ReturnType<typeof jest.fn>;
+  generate: Mock<(messages: unknown) => Promise<{ text: string }>>;
   prompts: string[];
 }
 
 function createMockAgent(id: string, options: MockAgentOptions = {}): MockAgent {
   const prompts: string[] = [];
 
-  const generate = jest.fn(async (messages: unknown) => {
+  const generate = mock(async (messages: unknown) => {
     const prompt = Array.isArray(messages) ? String((messages[0] as { content?: unknown })?.content ?? '') : '';
     prompts.push(prompt);
     const respond = options.respond ?? (() => `Mock response from ${id}`);
@@ -187,7 +189,8 @@ describe('Routing Workflows', () => {
       await route('What is the weather?');
       const reports = await pollUntilComplete();
 
-      expect(reports.at(-1)?.completedTaskResults?.[0].id).toBe('weather-check');
+      const lastReport = reports[reports.length - 1];
+      expect(lastReport.completedTaskResults?.[0].id).toBe('weather-check');
     });
   });
 
@@ -322,21 +325,21 @@ describe('Routing Workflows', () => {
 
       await route('What is the weather where I am?');
 
-      const pending = assertSuccess(await runWorkflow(getCurrentDagWorkflow, {}), z.any());
+      const pending = assertSuccess(await runWorkflow(getCurrentDagWorkflow, {}), dagSchema);
       expect(pending.userQuery).toBe('What is the weather where I am?');
-      expect(pending.tasks.map((task: { id: string; status: string }) => [task.id, task.status])).toEqual([
+      expect(pending.tasks.map((task) => [task.id, task.status])).toEqual([
         ['get-location', 'pending'],
         ['get-weather', 'pending'],
       ]);
 
       await pollUntilComplete();
 
-      const done = assertSuccess(await runWorkflow(getCurrentDagWorkflow, {}), z.any());
-      expect(done.tasks.every((task: { status: string }) => task.status === 'completed')).toBe(true);
+      const done = assertSuccess(await runWorkflow(getCurrentDagWorkflow, {}), dagSchema);
+      expect(done.tasks.every((task) => task.status === 'completed')).toBe(true);
     });
 
     it('is empty before anything has been routed', async () => {
-      const dag = assertSuccess(await runWorkflow(getCurrentDagWorkflow, {}), z.any());
+      const dag = assertSuccess(await runWorkflow(getCurrentDagWorkflow, {}), dagSchema);
       expect(dag.tasks).toEqual([]);
     });
   });

--- a/mcp/mastra/verticals/shopping/tools.spec.ts
+++ b/mcp/mastra/verticals/shopping/tools.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { findProductInCatalog, getCurrentCartContents } from './tools';
 
 describe('Shopping Tools Integration Tests', () => {
   describe('findProductInCatalog', () => {
     it('should search for products in the catalog', async () => {
-      const result = await findProductInCatalog.execute({
+      const result = await executeTool(findProductInCatalog, {
         search_query: 'mælk',
       });
 
@@ -32,7 +33,7 @@ describe('Shopping Tools Integration Tests', () => {
 
   describe('getCurrentCartContents', () => {
     it('should retrieve cart contents', async () => {
-      const result = await getCurrentCartContents.execute({});
+      const result = await executeTool(getCurrentCartContents, {});
 
       // Validate structure
       expect(result).toBeDefined();

--- a/mcp/mastra/verticals/synapse/subscription-expiry.spec.ts
+++ b/mcp/mastra/verticals/synapse/subscription-expiry.spec.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from 'bun:test';
 import type { Subscription } from '../../storage/subscriptions.js';
+import { executeTool } from '../../utils/tool-factory.js';
 import { formatSubscriptionMatches, type SubscriptionMatch } from './subscription-matcher.js';
 import { registerSubscription, removeSubscription } from './subscription-tools.js';
 
@@ -25,49 +26,49 @@ describe('registerSubscription refusing an endless subscription', () => {
     // The cost of forgetting is invisible and cumulative — an endless subscription is
     // scored against every state change forever and nothing ever removes it — so this
     // fails loudly rather than quietly accepting one.
-    expect(registerSubscription.execute({ ...BASE })).rejects.toThrow(/needs an end/);
+    await expect(executeTool(registerSubscription, { ...BASE })).rejects.toThrow(/needs an end/);
   });
 
   it('explains both ways of supplying one, so the model can retry', async () => {
-    expect(registerSubscription.execute({ ...BASE })).rejects.toThrow(/maxTriggerCount/);
-    expect(registerSubscription.execute({ ...BASE })).rejects.toThrow(/expiresAt/);
+    await expect(executeTool(registerSubscription, { ...BASE })).rejects.toThrow(/maxTriggerCount/);
+    await expect(executeTool(registerSubscription, { ...BASE })).rejects.toThrow(/expiresAt/);
   });
 
   it('accepts oneShot, which supplies the budget implicitly', async () => {
     // oneShot means "fire once", which is an end. Demanding maxTriggerCount as well
     // would be asking the model to say the same thing twice.
-    const result = await registerSubscription.execute({ ...BASE, oneShot: true });
+    const result = await executeTool(registerSubscription, { ...BASE, oneShot: true });
 
     try {
       expect(result.registered).toBe(true);
       expect(result.subscription.maxTriggerCount).toBe(1);
     } finally {
-      await removeSubscription.execute({ subscriptionId: result.subscription.id });
+      await executeTool(removeSubscription, { subscriptionId: result.subscription.id });
     }
   });
 
   it('accepts a deadline on its own', async () => {
     const expiresAt = new Date(Date.now() + 60_000).toISOString();
-    const result = await registerSubscription.execute({ ...BASE, expiresAt });
+    const result = await executeTool(registerSubscription, { ...BASE, expiresAt });
 
     try {
       expect(result.subscription.expiresAt).toBe(expiresAt);
       expect(result.subscription.maxTriggerCount).toBeNull();
     } finally {
-      await removeSubscription.execute({ subscriptionId: result.subscription.id });
+      await executeTool(removeSubscription, { subscriptionId: result.subscription.id });
     }
   });
 
   it('accepts a budget on its own, and keeps both when given both', async () => {
     const expiresAt = new Date(Date.now() + 60_000).toISOString();
-    const result = await registerSubscription.execute({ ...BASE, maxTriggerCount: 5, expiresAt });
+    const result = await executeTool(registerSubscription, { ...BASE, maxTriggerCount: 5, expiresAt });
 
     try {
       // Whichever comes first ends the subscription.
       expect(result.subscription.maxTriggerCount).toBe(5);
       expect(result.subscription.expiresAt).toBe(expiresAt);
     } finally {
-      await removeSubscription.execute({ subscriptionId: result.subscription.id });
+      await executeTool(removeSubscription, { subscriptionId: result.subscription.id });
     }
   });
 });

--- a/mcp/mastra/verticals/synapse/subscription-matcher.spec.ts
+++ b/mcp/mastra/verticals/synapse/subscription-matcher.spec.ts
@@ -23,6 +23,9 @@ async function embedSubscription(draft: SubscriptionDraft, index: number): Promi
     createdAt: new Date().toISOString(),
     lastTriggeredAt: null,
     triggerCount: 0,
+    // Ranking never looks at how a subscription ends, so these fixtures leave it open.
+    maxTriggerCount: null,
+    expiresAt: null,
     whenEmbedding: await embedText(draft.whenEvent),
     givenEmbedding: draft.givenCondition ? await embedText(draft.givenCondition) : null,
   };

--- a/mcp/mastra/verticals/synapse/tools.spec.ts
+++ b/mcp/mastra/verticals/synapse/tools.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'bun:test';
-import { synapseTools } from './tools';
+import { executeTool } from '../../utils/tool-factory.js';
+import { synapseTools } from './tools.js';
 
 describe('Synapse Tools Integration Tests', () => {
   describe('registerStateChange', () => {
     it('should register a state change successfully', async () => {
-      const result = await synapseTools.registerStateChange.execute({
+      const result = await executeTool(synapseTools.registerStateChange, {
         source: 'test',
         stateType: 'test_state_change',
         stateData: {
@@ -28,7 +29,7 @@ describe('Synapse Tools Integration Tests', () => {
 
   describe('getStateChangeBatcherStats', () => {
     it('should return batcher statistics', async () => {
-      const result = await synapseTools.getStateChangeBatcherStats.execute({});
+      const result = await executeTool(synapseTools.getStateChangeBatcherStats, {});
 
       // Validate structure
       expect(result).toBeDefined();
@@ -50,14 +51,14 @@ describe('Synapse Tools Integration Tests', () => {
   describe('flushStateChanges', () => {
     it('should flush pending state changes', async () => {
       // First register a change
-      await synapseTools.registerStateChange.execute({
+      await executeTool(synapseTools.registerStateChange, {
         source: 'test',
         stateType: 'test_flush',
         stateData: { test: 'data' },
       });
 
       // Then flush
-      const result = await synapseTools.flushStateChanges.execute({});
+      const result = await executeTool(synapseTools.flushStateChanges, {});
 
       // Validate structure
       expect(result).toBeDefined();
@@ -72,7 +73,7 @@ describe('Synapse Tools Integration Tests', () => {
 
   describe('subscriptions', () => {
     it('should register, retrieve, trigger and remove a Given/When/Then subscription', async () => {
-      const registered = await synapseTools.registerSubscription.execute({
+      const registered = await executeTool(synapseTools.registerSubscription, {
         whenEvent: 'the sun goes down',
         givenCondition: 'the lights are on',
         thenAction: 'close the blinds',
@@ -89,11 +90,11 @@ describe('Synapse Tools Integration Tests', () => {
       const subscriptionId = registered.subscription.id;
 
       try {
-        const listed = await synapseTools.listSubscriptions.execute({ includeDisabled: false });
+        const listed = await executeTool(synapseTools.listSubscriptions, { includeDisabled: false });
         expect(listed.subscriptions.some((subscription) => subscription.id === subscriptionId)).toBe(true);
 
         // Vector retrieval should surface it from a paraphrase of the WHEN.
-        const found = await synapseTools.findRelevantSubscriptions.execute({
+        const found = await executeTool(synapseTools.findRelevantSubscriptions, {
           description: 'the sun has gone down and it is getting dark outside',
           minimumScore: 0.3,
           maximumMatches: 5,
@@ -103,24 +104,24 @@ describe('Synapse Tools Integration Tests', () => {
         expect(match?.whenScore ?? 0).toBeGreaterThan(0.3);
 
         // One-shot subscriptions retire once they fire.
-        const triggered = await synapseTools.markSubscriptionTriggered.execute({ subscriptionId });
+        const triggered = await executeTool(synapseTools.markSubscriptionTriggered, { subscriptionId });
         expect(triggered.triggered).toBe(true);
         expect(triggered.stillEnabled).toBe(false);
 
-        const afterTrigger = await synapseTools.listSubscriptions.execute({ includeDisabled: false });
+        const afterTrigger = await executeTool(synapseTools.listSubscriptions, { includeDisabled: false });
         expect(afterTrigger.subscriptions.some((subscription) => subscription.id === subscriptionId)).toBe(false);
 
         console.log('✅ Subscription lifecycle verified');
         console.log('   - Id:', subscriptionId);
         console.log('   - WHEN similarity:', match?.whenScore);
       } finally {
-        const removed = await synapseTools.removeSubscription.execute({ subscriptionId });
+        const removed = await executeTool(synapseTools.removeSubscription, { subscriptionId });
         expect(removed.removed).toBe(true);
       }
     }, 15000);
 
     it('should not match a subscription against an unrelated state change', async () => {
-      const registered = await synapseTools.registerSubscription.execute({
+      const registered = await executeTool(synapseTools.registerSubscription, {
         whenEvent: 'the milk in the fridge expires',
         thenAction: 'add milk to the shopping list',
         source: 'synapse-tools-spec',
@@ -131,7 +132,7 @@ describe('Synapse Tools Integration Tests', () => {
       });
 
       try {
-        const found = await synapseTools.findRelevantSubscriptions.execute({
+        const found = await executeTool(synapseTools.findRelevantSubscriptions, {
           description: 'coding pull request opened: title is Refactor the deployment script',
           minimumScore: 0.3,
           maximumMatches: 5,
@@ -139,7 +140,7 @@ describe('Synapse Tools Integration Tests', () => {
 
         expect(found.matches.some((candidate) => candidate.subscription.id === registered.subscription.id)).toBe(false);
       } finally {
-        await synapseTools.removeSubscription.execute({ subscriptionId: registered.subscription.id });
+        await executeTool(synapseTools.removeSubscription, { subscriptionId: registered.subscription.id });
       }
     }, 15000);
   });

--- a/mcp/mastra/verticals/todo-list/tools.spec.ts
+++ b/mcp/mastra/verticals/todo-list/tools.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { getAllTaskLists, getAllTasks } from './tools';
 
 describe('Todo List Tools Integration Tests', () => {
@@ -17,7 +18,7 @@ describe('Todo List Tools Integration Tests', () => {
 
   describe('getAllTaskLists', () => {
     it('should retrieve all task lists', async () => {
-      const result = await getAllTaskLists.execute({});
+      const result = await executeTool(getAllTaskLists, {});
 
       // Validate structure
       expect(result).toBeDefined();
@@ -30,8 +31,11 @@ describe('Todo List Tools Integration Tests', () => {
 
   describe('getAllTasks', () => {
     it('should retrieve all tasks', async () => {
-      const result = await getAllTasks.execute({
+      // Mastra types the call site with the schema's *output*, so the defaulted
+      // fields have to be spelled out here.
+      const result = await executeTool(getAllTasks, {
         taskListId: '@default',
+        showCompleted: false,
         maxResults: 10,
       });
 

--- a/mcp/mastra/verticals/weather/tools.spec.ts
+++ b/mcp/mastra/verticals/weather/tools.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
+import { executeTool } from '../../utils/tool-factory.js';
 import { weatherTools } from './tools';
 
 describe('Weather Tools Integration Tests', () => {
@@ -11,7 +12,7 @@ describe('Weather Tools Integration Tests', () => {
 
   describe('getCurrentWeatherByCity', () => {
     it('should fetch current weather for a city', async () => {
-      const result = await weatherTools.getCurrentWeatherByCity.execute({
+      const result = await executeTool(weatherTools.getCurrentWeatherByCity, {
         cityName: 'aarhus,dk',
       });
 
@@ -49,7 +50,7 @@ describe('Weather Tools Integration Tests', () => {
 
     it('should handle invalid city gracefully', async () => {
       await expect(async () => {
-        await weatherTools.getCurrentWeatherByCity.execute({
+        await executeTool(weatherTools.getCurrentWeatherByCity, {
           cityName: 'thiscitydoesnotexist123456',
         });
       }).toThrow();
@@ -59,7 +60,7 @@ describe('Weather Tools Integration Tests', () => {
   describe('getCurrentWeatherByCoordinates', () => {
     it('should fetch current weather for GPS coordinates', async () => {
       // Coordinates for Aarhus, Denmark
-      const result = await weatherTools.getCurrentWeatherByCoordinates.execute({
+      const result = await executeTool(weatherTools.getCurrentWeatherByCoordinates, {
         latitude: 56.1629,
         longitude: 10.2039,
       });
@@ -94,7 +95,7 @@ describe('Weather Tools Integration Tests', () => {
 
   describe('getForecastByCity', () => {
     it('should fetch 5-day forecast for a city', async () => {
-      const result = await weatherTools.getForecastByCity.execute({
+      const result = await executeTool(weatherTools.getForecastByCity, {
         cityName: 'aarhus,dk',
       });
 
@@ -133,7 +134,7 @@ describe('Weather Tools Integration Tests', () => {
   describe('getForecastByCoordinates', () => {
     it('should fetch 5-day forecast for GPS coordinates', async () => {
       // Coordinates for Aarhus, Denmark
-      const result = await weatherTools.getForecastByCoordinates.execute({
+      const result = await executeTool(weatherTools.getForecastByCoordinates, {
         latitude: 56.1629,
         longitude: 10.2039,
       });

--- a/mcp/mastra/verticals/weather/workflows.spec.ts
+++ b/mcp/mastra/verticals/weather/workflows.spec.ts
@@ -1,7 +1,25 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 import { Mastra } from '@mastra/core';
+import { z } from 'zod';
 import { isOllamaAvailable } from '../../utils/providers/ollama-provider.js';
 import { weatherMonitoringWorkflow } from './workflows.js';
+
+const workflowResultSchema = z.object({
+  registered: z.boolean(),
+  message: z.string(),
+});
+
+/**
+ * Asserts the run succeeded and hands back its typed result.
+ *
+ * Mastra's run result is a discriminated union in which `result` only exists on
+ * the success branch, so the status has to be narrowed rather than merely
+ * asserted on.
+ */
+function expectSuccessfulResult(execution: { status: string; result?: unknown }) {
+  expect(execution.status).toBe('success');
+  return workflowResultSchema.parse(execution.result);
+}
 
 describe('weatherMonitoringWorkflow', () => {
   let ollamaAvailable = false;
@@ -43,11 +61,11 @@ describe('weatherMonitoringWorkflow', () => {
 
     // Verify the workflow completes successfully
     expect(execution).toBeDefined();
-    expect(execution.status).toBe('success');
-    expect(execution.result).toBeDefined();
-    expect(execution.result.registered).toBeDefined();
-    expect(typeof execution.result.registered).toBe('boolean');
-    expect(typeof execution.result.message).toBe('string');
+
+    const result = expectSuccessfulResult(execution);
+    expect(result.registered).toBeDefined();
+    expect(typeof result.registered).toBe('boolean');
+    expect(typeof result.message).toBe('string');
   }, 120000); // Increased timeout to allow for model pulling
 
   it('should complete workflow with proper structure', async () => {
@@ -61,12 +79,12 @@ describe('weatherMonitoringWorkflow', () => {
     const execution = await run.start({ inputData: {} });
 
     // Verify that the workflow completed
-    expect(execution.status).toBe('success');
-    expect(execution.result).toBeDefined();
+    const result = expectSuccessfulResult(execution);
+    expect(result).toBeDefined();
 
     // Verify the result has the expected keys
-    expect('registered' in execution.result).toBe(true);
-    expect('message' in execution.result).toBe(true);
+    expect('registered' in result).toBe(true);
+    expect('message' in result).toBe(true);
   }, 120000); // Increased timeout to allow for model pulling
 
   it('should have correct workflow structure', () => {

--- a/mcp/tests/mcp-client-connection.spec.ts
+++ b/mcp/tests/mcp-client-connection.spec.ts
@@ -1,3 +1,4 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { MCPClient } from '@mastra/mcp';
 import {
   createMcpClient,

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -6,6 +6,6 @@
     "tsBuildInfoFile": "../dist/mcp/tsconfig.tsbuildinfo",
     "types": ["bun-types", "node"]
   },
-  "include": ["mastra/**/*", "lib/**/*"],
-  "exclude": ["**/node_modules", "**/.*/", "**/dist", "**/build", "**/*.spec.ts", "tests/**/*"]
+  "include": ["mastra/**/*", "lib/**/*", "tests/**/*"],
+  "exclude": ["**/node_modules", "**/.*/", "**/dist", "**/build"]
 }


### PR DESCRIPTION
Fixes 1, 2 and 3 from the review follow-up. **337 tests pass; typecheck now covers every one of them.**

Note this branch contains the `fix/reliability-and-retention` work too (#675) — the human-in-the-loop agent needed those specs as its baseline and restored them.

## 1 — the email approval loop now closes

Previously `processFormReplies` parsed a token out of the subject and gave up:

```
⚠️  Workflow run retrieval not yet implemented. Skipping workflow ...
```

It could not do otherwise: the token was the **workflow id**, a constant shared by every run and every user. Now a request email carries the id of the run it suspended, the sweeper recovers that run via `getWorkflowRunById` + `createWorkflowStateReader`, and the reply body is parsed into the typed answer by `getEmailParsingAgent` — which existed for exactly this and was wired into nothing.

The other seven bugs went with it: the demo workflow could never reach `format-final-output` (a required `vendorName` no preceding step produced); a wrong-sender reply destroyed the pending request instead of being refused; budget rejection was thrown as an error despite the output schema modelling it as an outcome; the suspend payload was empty; the 14-day timeout existed only in the email text; and the demo defaulted to mailing `demo@example.com` from a Studio-registered workflow.

### The review caught the one that mattered

An adversarial reviewer **reproduced** a bug the fix had introduced-by-omission: all three stages of a run share the run id, so every request email carried an identical token, and a duplicate reply to an already-answered email was applied to whichever question was open next.

> Boss replies "Yes go ahead" to the **budget** email → run advances. Boss replies again to the **same** email → that answer is fed to the **vendor** question, and the next email goes out as `Final confirmation for project "Atlas" with vendor "Yes go ahead"`. Summary: `{ workflowsResumed: 1, repliesRejected: 0, errors: [] }`.

Each request now mints its own id (`[RUN-{runId}/REQ-{requestId}]`), required on the resume schema and checked before anything else. A stale reply is refused, the request stays open for the person actually asked, and the refusal is counted and surfaced in the scheduled run's output rather than only a console line.

A second reviewer reproduced the attack independently from scratch, confirmed it now fails, then **neutered the guard to confirm the regression test actually catches it** — and got the original symptom back.

## 2 — workflow failures reach the caller

`extractWorkflowError` only unwrapped `result.error` when it was an `Error`. Mastra serialises it with `Error.prototype.toJSON` before the result leaves the engine (confirmed in `agent-B2LHedIt.js:3368` → `formatResultError`), so the field holds a plain object despite its declared type. Every failed workflow returned the generic status line over HTTP while the real cause went only to the server log.

Now handles `Error` / plain object / bare string / absent, and lives in `utils/errors.ts` so the email sweeper uses it for the same job instead of reading `.error.message` directly.

## 3 — the tests are typechecked

Specs were excluded from `tsconfig.json`; **530 type errors** had accumulated across 21 files. Almost all one cause: specs called `tool.execute()` directly, which Mastra types so the result collapses to `void`, so every property access failed. The repo already had `executeTool` — which supplies the execution context and narrows the result — and the specs weren't using it.

**This found real bugs, not noise:**

- `email/tools.spec.ts` passed `from` and `maxResults` to a tool accepting neither. Both were silently dropped, so the test named *"should support filtering by sender"* filtered nothing and asserted exactly what the test above it asserted.
- Making it use the real parameter then **failed against Graph**: `findEmails` sends `$search` together with `$orderby`, which Graph rejects with `SearchWithOrderBy` (HTTP 400). **Searching has never worked.** Fixed by dropping `$orderby` when searching — Graph orders search hits by relevance anyway.
- Specs were passing `{}` as an execution context Mastra requires fields on, working only because those tools ignore the argument, and asserting through nine non-null `!` assertions on `execute`.

Zero `as any`, `@ts-ignore` or non-null `!` were introduced; the repo still has none.

## Known and deliberately not fixed

- `getSuspendedStep()` returns the *first* suspended step, so two send-and-wait workflows in a `.parallel()` would misroute. No such workflow exists; latent, and noted.
- Message rows still accumulate in Mastra's own table (see #675 — the expensive half, the per-event hosted embedding, is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
