### PR TITLE
fix(email): match a reply to the question it answers, not the first one waiting

### DIFF
--- a/mcp/mastra/verticals/email/workflows.spec.ts
+++ b/mcp/mastra/verticals/email/workflows.spec.ts
@@ -73,9 +73,12 @@ mock.module('../human-in-the-loop/agents.js', () => ({
   },
 }));
 
-const { buildFormRequestSubject, getSendEmailAndAwaitResponseWorkflow, humanInTheLoopDemoWorkflow } = await import(
-  '../human-in-the-loop/workflows.js'
-);
+const {
+  buildFormRequestSubject,
+  getSendEmailAndAwaitResponseWorkflow,
+  humanInTheLoopDemoWorkflow,
+  parseFormRequestSubject,
+} = await import('../human-in-the-loop/workflows.js');
 const { formRepliesDetectionWorkflow } = await import('./workflows.js');
 
 /** Narrows a workflow result so the status-specific fields are reachable. */
@@ -113,6 +116,25 @@ const awaitSomethingElseWorkflow = createWorkflow({
       execute: async ({ resumeData, suspend }) => resumeData ?? (await suspend({})),
     }),
   )
+  .commit();
+
+/**
+ * Two questions asked at once.
+ *
+ * A run can hold more than one suspension, and this is the shape that produces it. It
+ * exists because the reply handler used to ask the state reader for "the" suspended step,
+ * which is defined as the first of them: every reply was offered to whichever sorted
+ * first, so the other question could never be answered by email at all.
+ */
+const askTwoAtOnceWorkflow = createWorkflow({
+  id: 'askTwoAtOnceWorkflow',
+  inputSchema: z.object({ recipientEmail: z.string(), question: z.string() }),
+  outputSchema: z.object({}).loose(),
+})
+  .parallel([
+    getSendEmailAndAwaitResponseWorkflow('firstOfTwo', approvalResponseSchema),
+    getSendEmailAndAwaitResponseWorkflow('secondOfTwo', approvalResponseSchema),
+  ])
   .commit();
 
 const RESUME_FAILURE_MESSAGE = 'the ledger refused the approval';
@@ -170,6 +192,7 @@ const mastra = new Mastra({
     awaitApprovalWorkflow,
     awaitSomethingElseWorkflow,
     failsAfterReplyWorkflow,
+    askTwoAtOnceWorkflow,
     humanInTheLoopDemoWorkflow,
     formReplyHarness,
   },
@@ -547,5 +570,57 @@ describe('processFormReplies', () => {
 
     expect(summary).toMatchObject({ emailsProcessed: 2, formRepliesFound: 2, workflowsResumed: 1 });
     expect(summary.errors).toHaveLength(1);
+  });
+});
+
+describe('a run waiting on two questions at once', () => {
+  /** Starts the parallel workflow and returns the two request emails it sent. */
+  async function askTwoQuestions() {
+    const run = await mastra.getWorkflow('askTwoAtOnceWorkflow').createRun();
+    const started = await run.start({
+      inputData: { recipientEmail: 'boss@example.com', question: 'Approve?' },
+    });
+
+    assertStatus(started, 'suspended');
+    expect(sentEmails).toHaveLength(2);
+
+    return sentEmails.map((email) => email.subject);
+  }
+
+  it('answers the question the reply was sent for, not whichever suspended first', async () => {
+    const [firstSubject, secondSubject] = await askTwoQuestions();
+
+    // Two suspensions, two distinct request ids.
+    expect(parseFormRequestSubject(firstSubject)?.requestId).not.toBe(
+      parseFormRequestSubject(secondSubject)?.requestId,
+    );
+
+    stagedAnswer = { approved: true };
+    const summary = await processReplies([
+      inboundReply({ subject: `Re: ${secondSubject}`, from: 'boss@example.com', content: 'Yes' }),
+    ]);
+
+    // Before the reply handler matched on the request id, this reply was offered to the
+    // first suspended step, which refused it -- so the run advanced not at all and the
+    // second question was unanswerable by email for as long as the first stayed open.
+    expect(summary).toMatchObject({ formRepliesFound: 1, workflowsResumed: 1, repliesRejected: 0, errors: [] });
+    expect(parsedReplyBodies).toEqual(['Yes']);
+  });
+
+  it('still lets the other question be answered afterwards', async () => {
+    const [firstSubject, secondSubject] = await askTwoQuestions();
+
+    stagedAnswer = { approved: true };
+    await processReplies([
+      inboundReply({ subject: `Re: ${secondSubject}`, from: 'boss@example.com', content: 'Yes to the second' }),
+    ]);
+
+    const summary = await processReplies([
+      inboundReply({ subject: `Re: ${firstSubject}`, from: 'boss@example.com', content: 'Yes to the first' }),
+    ]);
+
+    // Answering one must not strand the other: both were asked, both can be answered.
+    expect(summary).toMatchObject({ workflowsResumed: 1, repliesRejected: 0, errors: [] });
+    expect(parsedReplyBodies).toEqual(['Yes to the second', 'Yes to the first']);
   });
 });

--- a/mcp/mastra/verticals/email/workflows.ts
+++ b/mcp/mastra/verticals/email/workflows.ts
@@ -404,7 +404,7 @@ type RunLookup =
  * A run that is found but cannot take the reply does not end the search, because a run id
  * is only unique per workflow; the reason is reported only if no workflow is waiting.
  */
-async function findRunAwaitingEmailReply(mastra: Mastra, runId: string): Promise<RunLookup> {
+async function findRunAwaitingEmailReply(mastra: Mastra, runId: string, requestId: string): Promise<RunLookup> {
   let firstRunThatCannotTakeIt: string | undefined;
 
   for (const workflow of Object.values(mastra.listWorkflows())) {
@@ -413,21 +413,57 @@ async function findRunAwaitingEmailReply(mastra: Mastra, runId: string): Promise
       continue;
     }
 
-    const suspendedStep =
-      state.status === 'suspended' ? createWorkflowStateReader(state).getSuspendedStep() : undefined;
+    const reader = state.status === 'suspended' ? createWorkflowStateReader(state) : undefined;
+    const suspendedSteps = reader?.getSuspendedSteps() ?? [];
+    const awaitingSteps = suspendedSteps.filter((step) => isAwaitingEmailReply(step.path));
 
-    const suspendedPath = suspendedStep?.path;
+    // Pick the question this reply actually answers.
+    //
+    // A run can hold more than one suspension at once — two send-and-wait workflows in a
+    // `.parallel()` both wait at the same time — and the reader's singular
+    // `getSuspendedStep()` is defined as `getSuspendedSteps()[0]`, so it hands back
+    // whichever sorts first and silently drops the rest. Every reply would then be offered
+    // to that same step; the step's own request-id check would correctly refuse the ones
+    // meant for its sibling, but those questions could never be answered by email at all,
+    // because no reply would ever be shown to them.
+    //
+    // Falling back to the first awaiting step keeps the ordinary single-question case
+    // exactly as it was: the reply is offered, and the step decides whether it answers the
+    // request it is waiting on.
+    const suspendedStep = awaitingSteps.find((step) => requestIdWaitedOnBy(step) === requestId) ?? awaitingSteps[0];
 
-    if (suspendedStep && isAwaitingEmailReply(suspendedPath)) {
+    if (suspendedStep) {
       return { kind: 'awaiting', workflow, suspendedStep };
     }
 
-    firstRunThatCannotTakeIt ??= describeRunThatCannotTakeTheReply(workflow.id, runId, state.status, suspendedPath);
+    firstRunThatCannotTakeIt ??= describeRunThatCannotTakeTheReply(
+      workflow.id,
+      runId,
+      state.status,
+      suspendedSteps[0]?.path,
+    );
   }
 
   return firstRunThatCannotTakeIt
     ? { kind: 'not-awaiting', description: firstRunThatCannotTakeIt }
     : { kind: 'not-found', description: `No workflow run with id ${runId} was found` };
+}
+
+/**
+ * The request id a suspended step is waiting on, when it recorded one.
+ *
+ * `suspendPayload` is typed `any` by Mastra, so it is narrowed here rather than trusted,
+ * keeping the `any` from spreading into the caller.
+ */
+function requestIdWaitedOnBy(step: WorkflowSuspendedStep): string | undefined {
+  const payload: unknown = step.suspendPayload;
+
+  if (payload && typeof payload === 'object' && 'requestId' in payload) {
+    const { requestId } = payload as { requestId: unknown };
+    return typeof requestId === 'string' ? requestId : undefined;
+  }
+
+  return undefined;
 }
 
 /**
@@ -471,7 +507,7 @@ async function applyFormReply(
   email: z.infer<typeof emailObjectSchema>,
   { runId, requestId }: { runId: string; requestId: string },
 ): Promise<FormReplyOutcome> {
-  const pendingRun = await findRunAwaitingEmailReply(mastra, runId);
+  const pendingRun = await findRunAwaitingEmailReply(mastra, runId, requestId);
   if (pendingRun.kind === 'not-found') {
     return { kind: 'unmatched', description: pendingRun.description };
   }


### PR DESCRIPTION
Closes the latent issue flagged in #676's review.

## The problem

A run can hold **more than one suspension at a time** — two send-and-wait workflows in a `.parallel()` both wait at once. But the reply handler asked for *the* suspended step:

```ts
const suspendedStep = createWorkflowStateReader(state).getSuspendedStep();
```

In `@mastra/core` 1.58.0 that is defined as:

```ts
getWorkflowSuspendedStep = state => getWorkflowSuspendedSteps(state)[0]
```

It returns whichever sorts first and silently drops the rest.

So every reply would be offered to that same step. The per-request id check from #676 would **correctly refuse** the ones meant for its sibling — no wrong answer is ever recorded — but the sibling's question could never be answered by email at all, because no reply would ever be shown to it. A deadlock rather than a corruption, which is why this was worth fixing calmly rather than urgently.

## The fix

Read every suspended step and pick the one whose stored request id matches the id quoted in the subject. The snapshot already carried `suspendPayload.requestId` per suspended step, so nothing new has to be persisted.

Falling back to the first awaiting step keeps the ordinary single-question case **exactly as it was** — the reply is offered, and the step decides whether it answers the request it is waiting on. This changes behaviour only for runs that genuinely hold two questions open.

`suspendPayload` is typed `any` by Mastra, so it is narrowed in a small helper rather than trusted, keeping the `any` from spreading into the caller.

## Tests

Nothing in the repository puts two send-and-wait workflows in a `.parallel()`, so the regression test is the first thing to do it:

- **answers the question the reply was sent for** — two questions asked at once, reply to the *second*, assert it resumes rather than being refused
- **still lets the other question be answered afterwards** — answering one must not strand the other

Both were confirmed to **fail** with the selection reverted to `awaitingSteps[0]`, so they catch the thing they describe rather than passing by construction.

**339 tests pass, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhfcvteX3L2YyoHHv6byf5
