### PR TITLE
fix(mcp): stop the tunnel rejecting every agent stream as a bad gateway

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,7 +1,14 @@
 # Build stage - use Bun image for building
 # Pinned by digest so the base image is immutable; Dependabot keeps the tag and
 # digest in sync. Keep the version aligned with `packageManager` in package.json.
-FROM docker.io/oven/bun:1.3.9-alpine@sha256:9028ee7a60a04777190f0c3129ce49c73384d3fc918f3e5c75f5af188e431981 AS builder
+#
+# 1.3.10 or newer, and never back below it: up to 1.3.9 Bun emitted its own
+# `Transfer-Encoding: chunked` on top of one the application had already set, and Go's
+# net/http — which is how cloudflared reaches this origin — rejects a response carrying
+# the header twice. Every streaming route 502'd through the tunnel. `engines.bun` in
+# package.json holds the same floor, and mastra/streaming-headers.ts stops the
+# application from setting the header at all.
+FROM docker.io/oven/bun:1.3.14-alpine@sha256:5acc90a93e91ff07bf72aa90a7c9f0fa189765aec90b47bdbf2152d2196383c0 AS builder
 
 WORKDIR /workspace
 
@@ -33,7 +40,7 @@ COPY mcp/ ./mcp/
 FROM docker.io/1password/op:2.39.0@sha256:3cd5a1febc662c93d46b944b983b301e710da5c016ef63be9d436cf2b1ed30d5 AS onepassword
 
 # Production stage - use Bun Alpine for runtime (needed for mastra studio CLI)
-FROM docker.io/oven/bun:1.3.9-alpine@sha256:9028ee7a60a04777190f0c3129ce49c73384d3fc918f3e5c75f5af188e431981 AS production
+FROM docker.io/oven/bun:1.3.14-alpine@sha256:5acc90a93e91ff07bf72aa90a7c9f0fa189765aec90b47bdbf2152d2196383c0 AS production
 
 ENV HOST=0.0.0.0
 ENV NODE_ENV=production

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -240,6 +240,7 @@ image — because CORS never applies there.
 | Symptom | Cause |
 | --- | --- |
 | Cloudflare sign-in page instead of Studio | Access policy rejected you. Browser access needs an identity (email) policy; a service-token policy must use the **Service Auth** action (`non_identity`), since an `allow` action still demands an identity. |
+| Studio loads, but every agent chat comes back as a Cloudflare `502` | The origin answered a streaming route with `Transfer-Encoding: chunked` twice, and `cloudflared` — a Go HTTP client — refuses that outright. `docker logs <tunnel container>` shows `too many transfer encodings: ["chunked" "chunked"]` against `/api/agents/.../stream` or `/threads/subscribe`. Non-streaming routes are unaffected, which is why the UI itself looks healthy. Guarded on both sides now: `mastra/streaming-headers.ts` stops the application from setting the header, and the image runs Bun ≥ 1.3.10, which no longer duplicates it. |
 | `404` on `/agents`, but `/health` works | The API server is running without Studio — use `serve:all`, not `serve`. |
 | Tunnel connects but serves the wrong thing | The hostname's ingress points at the other port. 4111 is Studio, 4112 is MCP. |
 

--- a/mcp/mastra/index.ts
+++ b/mcp/mastra/index.ts
@@ -7,6 +7,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { getCorsOptions } from './cors.js';
 import { getTokenUsageStorage } from './storage/index.js';
+import { stripTransferEncodingHeader } from './streaming-headers.js';
 import { TokenTrackingProcessor, TokenUsageExporter } from './utils/token-usage-exporter.js';
 import { storageRetentionWorkflow, tokenUsageTools } from './verticals/api/index.js';
 import { calendarTools, getCalendarAgent } from './verticals/calendar/index.js';
@@ -129,6 +130,9 @@ export async function getMastra(): Promise<Mastra> {
     server: {
       studioBase: process.env.MASTRA_STUDIO_BASE_URL,
       port: process.env.MASTRA_SERVER_PORT ? Number(process.env.MASTRA_SERVER_PORT) : 4111,
+      // Applies to the server `mastra dev` builds around this instance — the one that
+      // actually serves 4111 in the Docker image. See streaming-headers.ts.
+      middleware: [stripTransferEncodingHeader],
     },
   });
 }
@@ -160,6 +164,9 @@ export async function logTokenUsageSummary(): Promise<void> {
 // We do not need any special adapters for Bun here; Hono works out of the box.
 const app = new Hono();
 app.use('*', cors(getCorsOptions()));
+// The `server.middleware` entry above covers `mastra dev`; this covers the same routes
+// when this file is served directly (`turbo serve --filter=mcp`).
+app.use('*', stripTransferEncodingHeader);
 
 export const mastra = await getMastra();
 

--- a/mcp/mastra/streaming-headers.spec.ts
+++ b/mcp/mastra/streaming-headers.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import { Hono } from 'hono';
+import { stream } from 'hono/streaming';
+import { stripTransferEncodingHeader } from './streaming-headers.js';
+
+/**
+ * Mirrors what `@mastra/hono` does for a route with `responseType: 'stream'` and
+ * `streamFormat: 'sse'`: it declares the transfer encoding itself, then streams.
+ */
+function createApp() {
+  const app = new Hono();
+  app.use('*', stripTransferEncodingHeader);
+
+  app.get('/api/agents/calendar/stream', (c) => {
+    c.header('Content-Type', 'text/event-stream');
+    c.header('Cache-Control', 'no-cache');
+    c.header('Transfer-Encoding', 'chunked');
+    return stream(c, async (s) => {
+      await s.write('data: {"chunk":1}\n\n');
+      await s.close();
+    });
+  });
+
+  app.get('/api/agents', (c) => c.json({ agents: [] }));
+
+  return app;
+}
+
+describe('stripTransferEncodingHeader', () => {
+  it('removes the transfer encoding a streaming route declares', async () => {
+    const response = await createApp().request('/api/agents/calendar/stream');
+
+    // Left in place, the HTTP server adds a second copy of this header and Go's
+    // net/http — the client cloudflared reaches the origin with — refuses the response
+    // with "too many transfer encodings".
+    expect(response.headers.get('Transfer-Encoding')).toBeNull();
+  });
+
+  it('leaves the rest of a streaming response alone', async () => {
+    const response = await createApp().request('/api/agents/calendar/stream');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(response.headers.get('Cache-Control')).toBe('no-cache');
+    expect(await response.text()).toBe('data: {"chunk":1}\n\n');
+  });
+
+  it('leaves non-streaming responses alone', async () => {
+    const response = await createApp().request('/api/agents');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ agents: [] });
+  });
+});

--- a/mcp/mastra/streaming-headers.ts
+++ b/mcp/mastra/streaming-headers.ts
@@ -1,0 +1,44 @@
+/**
+ * Response-header hygiene for streaming routes.
+ *
+ * Kept in its own module so it can be exercised in isolation, without importing
+ * `index.ts` and booting every agent and workflow.
+ */
+
+/**
+ * The part of a Hono context this middleware touches.
+ *
+ * Deliberately structural rather than Hono's own `MiddlewareHandler`: `@mastra/core`
+ * vendors its own copy of the Hono types, so a handler annotated with one package's
+ * `Context` will not typecheck against the other's. Naming only what is used keeps the
+ * handler assignable to both `app.use()` and Mastra's `server.middleware`.
+ */
+type ResponseContext = { res: Response };
+
+/**
+ * Removes the `Transfer-Encoding` header the application sets on streaming responses,
+ * leaving the framing to the HTTP server.
+ *
+ * `@mastra/hono` sets `Transfer-Encoding: chunked` itself on every route with
+ * `responseType: 'stream'` — agent streams, thread subscriptions, workflow watches. The
+ * HTTP server then adds the same header again when it frames a body that has no
+ * `Content-Length`, and Bun emitted both copies up to and including 1.3.9. A browser
+ * shrugs that off. Go's `net/http` does not:
+ *
+ * ```text
+ * too many transfer encodings: ["chunked" "chunked"]
+ * ```
+ *
+ * That is the client `cloudflared` uses to reach the origin, so through the tunnel every
+ * streaming route died before its first byte and Cloudflare answered the browser with a
+ * 502 page, while ordinary JSON routes kept working — the failure looked like a dead
+ * server rather than a malformed response.
+ *
+ * Deleting the header costs nothing: chunked framing is what an HTTP/1.1 server does for
+ * a body of unknown length whether or not the header was declared, so the response goes
+ * out chunked either way, with exactly one header announcing it.
+ */
+export const stripTransferEncodingHeader = async (c: ResponseContext, next: () => Promise<void>): Promise<void> => {
+  await next();
+  c.res.headers.delete('Transfer-Encoding');
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hey-jarvis",
   "version": "1.12.0",
-  "packageManager": "bun@1.3.9",
+  "packageManager": "bun@1.3.14",
   "description": "My digital assistant that runs the house",
   "main": "index.js",
   "workspaces": [
@@ -54,7 +54,7 @@
   },
   "//typescript": "Held at 6.x deliberately — do NOT bump to 7. TypeScript 7 is the native port and drops the legacy JS compiler API (ts.sys, ts.readConfigFile and ts.resolveModuleName are all undefined). typescript-paths, which @mastra/deployer depends on, peers on '^4.7.2 || ^5 || ^6' and calls ts.sys, so `mastra dev` dies at startup with \"undefined is not an object (evaluating 'host.readFile')\" — taking Studio on 4111 with it, and failing the container healthcheck. Typechecking does not go through this package; it uses tsgo from @typescript/native-preview.",
   "engines": {
-    "bun": ">=1.3.9"
+    "bun": ">=1.3.14"
   },
   "//overrides": "Transitive dependencies pinned forward to patched versions because their parents still request a vulnerable range. Every entry is a security fix — verify with `bun run audit` before removing one. Bun only honors flat overrides; the npm nested form is silently ignored.",
   "overrides": {


### PR DESCRIPTION
## The symptom

Mastra Studio loads over the Cloudflare tunnel, but every agent chat comes back as Cloudflare's 502 page. Nothing else looks wrong: the agent list, memory panel and `/health` all answer normally.

## The cause

The server was never down — `restarts=0`, `oomkilled=false`, `/health` returning 200 throughout the failure window. `cloudflared` was *refusing the response*:

```
ERR Request failed error="Unable to reach the origin service ... net/http: HTTP/1.x
transport connection broken: too many transfer encodings: [\"chunked\" \"chunked\"]"
dest=https://<studio-host>/api/agents/calendar/threads/subscribe
```

Two things stack up:

1. `@mastra/hono` sets `Transfer-Encoding: chunked` on the response itself for every route with `responseType: 'stream'` — agent streams, thread subscriptions, workflow watches (`node_modules/@mastra/hono/dist/index.js:292`).
2. The HTTP server adds the header again when it frames a body with no `Content-Length`. Bun emitted **both** copies up to and including 1.3.9 — the version this image was pinned to.

Browsers tolerate a duplicated transfer encoding. Go's `net/http` — the client `cloudflared` uses to reach the origin — treats it as a fatal framing error and drops the connection, so Cloudflare answers the browser with a 502. Only streaming routes carry the header, which is why the UI looked healthy while every chat failed.

Verified by reproducing the exact stack (Hono + `@hono/node-server`) on both Bun versions and reading the raw bytes off the socket:

| | Bun 1.3.9 | Bun 1.3.14 |
| --- | --- | --- |
| app sets the header | **2×** `Transfer-Encoding` | 1× |
| app does not | 1× | 1× |

## The fix

Both sides, so neither has to be trusted on its own:

- **`mcp/mastra/streaming-headers.ts`** — middleware that deletes the application's `Transfer-Encoding` header after the handler runs, leaving the framing to the HTTP server, which adds exactly one. Registered as `server.middleware` (the server `mastra dev` builds around the instance — the one that actually serves 4111 in the image) and on the Hono app in `index.ts` for the plain `serve` target.
- **Bun 1.3.14 in the image** (`engines.bun` holds the same floor, and the Dockerfile comment says why, so nobody pins back below 1.3.10). 1.4.0 shipped today, so it is left to Dependabot rather than taken here.

## Verification

- Confirmed `server.middleware` reaches streaming routes by probing `POST /api/agents/calendar/threads/subscribe` on a real `mastra dev` server: the app-set header is gone, one server-added `Transfer-Encoding` remains, framing intact.
- `bunx turbo lint --filter=mcp` (lint + typecheck) passes.
- `bun test mcp/mastra`: 411 pass / 14 fail — the same 14 integration tests fail on a clean checkout here (they need credentials and network access to Home Assistant, Bilka and Google), and 3 of the new passes are this PR's spec.

## Deploying

The Pi is running `ghcr.io/ffmathy/mcp:1.10.0`, so this needs a released image before the 502 goes away.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGqvseKhg7j69DRQvAeuEm)_