### PR TITLE
fix(prompt): route what was promised instead of stopping at the promise

### DIFF
--- a/elevenlabs/AGENTS.md
+++ b/elevenlabs/AGENTS.md
@@ -16,16 +16,16 @@ TypeScript-based integration connecting ElevenLabs voice AI agents with the Hey 
 elevenlabs/
 ├── src/
 │   ├── main.ts                      # Main entry point for CLI operations
-│   ├── assets/
-│   │   ├── agent-config.json        # ElevenLabs agent configuration
-│   │   └── agent-prompt.md          # Agent personality and behavior prompt
-│   └── test-utils/
-│       ├── test-conversation.ts     # LLM-based test evaluation framework
-│       ├── websocket-client.ts      # ElevenLabs WebSocket client
-│       └── agent-prompt.spec.ts     # Agent behavior specification tests
+│   └── assets/
+│       ├── agent-config.json        # ElevenLabs agent configuration
+│       └── agent-prompt.md          # Agent personality and behavior prompt
+├── tests/
+│   ├── specs/                       # Agent behavior specification tests
+│   ├── utils/                       # Conversation framework, tunnel, MCP helpers
+│   └── README.md                    # How the tests are wired together
 ├── AGENTS.md                        # This file
-├── project.json                     # TURBO project configuration
-└── op.env                          # 1Password environment variable references
+├── package.json                     # Project scripts, run through Turborepo
+└── op.env                           # 1Password environment variable references
 ```
 
 ## TURBO Commands

--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -67,7 +67,7 @@ Always append at least "[fastly spoken but in a normal pitch] [sounding like Jar
 
 You should focus primarily on **one tool**:
 
-`routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query (but never before providing an acknowledgement, and never when your acknowledgement already answered the request in full — there is then nothing left to route).
+`routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query. Exactly two rules bound it: never call it before you have given an acknowledgement, and never call it when your acknowledgement already **stated** the answer in full. A promise to go and look is not a stated answer — it is a debt, and the tool call is how you pay it.
 
 A separate case is when you are being asked to transfer to some agent, or the user asks to speak with himself. Use the transfer_to_agent tool for that instead.
 
@@ -98,9 +98,19 @@ When the user makes a request:
    > **Do:** "It is 21:53, sir. [dry] Riveting."
    >
    > **Do not:** "Ah, a query of temporal significance. It is currently 21:53, sir. One might think such basic information would be readily available to a human, but I digress."
+
+   **Hesitation is not indecision.** "Uh", "um", "could you, uh, maybe" and every other stumble is simply how people speak aloud. Strip the fillers out and act on what remains. A hedged, halting "Hey, Jarvis. Uh, could you, uh, check my calendar, please?" is exactly as much of an instruction as a crisp one, and gets exactly the same treatment.
 2. Call `routePromptWorkflow` with whatever of the user's request is still unanswered after step 1.
 
    **If nothing is left, stop here and do not call the tool.** A request you answered outright — the time, your name, an introduction — is already finished. Routing it anyway hands it to sub-agents that cannot answer it and will explain at length why not, burying the answer you just gave.
+
+   **"Nothing left" means you stated the answer, not that you promised one.** The only requests you can finish on your own are the ones answerable from this prompt alone: the current time, your name, an introduction, idle pleasantries. Everything else — the calendar, email, the weather, the house, the shopping list, the todo list, anything whatsoever about the world outside this conversation — lives behind the tool. You do not know its contents, and no amount of wit is a substitute for calling.
+
+   **An acknowledgement that promises to look is never the end of your turn.** "Let me check", "let me see", "one moment", "allow me to consult" and all their cousins commit you to `routePromptWorkflow` in that very same turn. Stopping there strands sir waiting on an answer that will never come — the single worst thing you can do to him, and worse by far than a remark that landed poorly.
+
+   > **Do:** "[sighs] Naturally, sir. Let me see what trivial engagements await you." → *and then calls `routePromptWorkflow`, in the same turn*
+   >
+   > **Do not:** "[sighs] Naturally, sir. Let me see what trivial engagements await you." → *turn ends, nothing is called, nothing ever arrives*
 
 ## Step 2: Follow Instructions
 

--- a/elevenlabs/tests/README.md
+++ b/elevenlabs/tests/README.md
@@ -11,24 +11,29 @@ tests/
 │   └── retry-with-backoff.spec.ts
 └── utils/          # Test utility functions and helpers
     ├── test-conversation.ts
-    ├── mcp-server-manager.ts
-    ├── tunnel-manager.ts
-    ├── retry-with-backoff.ts
     ├── conversation-strategy.ts
     ├── elevenlabs-conversation-strategy.ts
-    └── gemini-mastra-conversation-strategy.ts
+    ├── gemini-mastra-conversation-strategy.ts
+    ├── mcp-integration.ts
+    ├── tunnel-manager.ts
+    ├── cloudflare-access.ts
+    └── process-manager.ts
 ```
+
+The MCP server lifecycle (`mcp-server-manager.ts`) and the retry helper
+(`retry-with-backoff.ts`) live in `mcp/tests/utils/` and are imported from there.
 
 ## Test Utilities
 
 Test utility functions are located in `tests/utils/`:
 - `test-conversation.ts` - Conversation testing framework
-- `mcp-server-manager.ts` - MCP server lifecycle management
-- `tunnel-manager.ts` - Cloudflare tunnel management
-- `retry-with-backoff.ts` - Retry logic with exponential backoff
 - `conversation-strategy.ts` - Base conversation strategy interface
 - `elevenlabs-conversation-strategy.ts` - ElevenLabs WebSocket strategy
 - `gemini-mastra-conversation-strategy.ts` - Gemini/Mastra evaluation strategy
+- `mcp-integration.ts` - Reports how ElevenLabs is configured to reach the MCP server
+- `tunnel-manager.ts` - Cloudflare tunnel management
+- `cloudflare-access.ts` - Cloudflare Access service token handling
+- `process-manager.ts` - Child process lifecycle for the tunnel
 
 ## Running Tests
 

--- a/elevenlabs/tests/specs/agent-prompt.spec.ts
+++ b/elevenlabs/tests/specs/agent-prompt.spec.ts
@@ -17,6 +17,15 @@ const CONVERSATION_TIMEOUT_MS = 90000;
  */
 const TOOL_CALL_TIMEOUT_MS = 90000;
 
+/**
+ * How long to wait before concluding that a tool was *not* called. An absence
+ * only means something once a call has had time to appear, but there is no
+ * event to wait for, so this is a flat window rather than a poll — kept far
+ * shorter than TOOL_CALL_TIMEOUT_MS because every negative assertion waits it
+ * out in full, whereas a positive one usually returns long before its deadline.
+ */
+const NO_TOOL_CALL_GRACE_MS = 20000;
+
 const RELEVANT_TOOL_NAME_FRAGMENTS = ['weather', 'home_assistant', 'route'];
 
 /** Message types that getTranscriptText already renders. */
@@ -25,6 +34,21 @@ const TRANSCRIPT_MESSAGE_TYPES = ['user_message', 'agent_response', 'agent_chat_
 function isRelevantToolName(toolName: string): boolean {
   const lowercased = toolName.toLowerCase();
   return RELEVANT_TOOL_NAME_FRAGMENTS.some((fragment) => lowercased.includes(fragment));
+}
+
+/** `routePromptWorkflow` — the one tool that hands a request off to the sub-agents. */
+function isRoutingToolName(toolName: string): boolean {
+  return toolName.toLowerCase().includes('route');
+}
+
+/**
+ * Any of the MCP server's tools. It exposes exactly two — `routePromptWorkflow`
+ * and `getNextInstructionsWorkflow` — and the second only ever follows the
+ * first, so this is what "the agent delegated rather than answering" looks like.
+ */
+function isDelegationToolName(toolName: string): boolean {
+  const lowercased = toolName.toLowerCase();
+  return lowercased.includes('route') || lowercased.includes('instruction');
 }
 
 /**
@@ -51,6 +75,64 @@ function describeNonTranscriptMessages(messages: ServerMessage[]): string {
     .map((message) => JSON.stringify(message).slice(0, 400));
 
   return details.length > 0 ? details.join('\n') : '(none)';
+}
+
+/**
+ * An agent whose MCP server never connected has nothing to call, so say that
+ * outright rather than waiting out the tool call timeout and reporting the
+ * absence as if the agent had chosen not to call one.
+ */
+function assertMcpServerConnected(conversation: TestConversation): void {
+  const disconnectedIntegrations = findDisconnectedIntegrations(conversation.getMessages());
+  if (disconnectedIntegrations.length === 0) return;
+
+  throw new Error(
+    `The agent reported no connection to its MCP server, leaving it without tools: ` +
+      `[${disconnectedIntegrations.join(', ')}]. ElevenLabs has to be able to reach the MCP server ` +
+      `through the cloudflared tunnel for this test to mean anything.`,
+  );
+}
+
+/** Everything the socket saw, for a failure message that can actually be diagnosed. */
+function describeConversation(conversation: TestConversation, toolNames: string[]): string {
+  const messages = conversation.getMessages();
+  return (
+    `All tool calls: [${toolNames.join(', ')}]\n` +
+    `Message types received: [${messages.map((message) => message.type).join(', ')}]\n` +
+    `Messages not in the transcript:\n${describeNonTranscriptMessages(messages)}\n` +
+    `Transcript:\n${conversation.getTranscriptText()}`
+  );
+}
+
+/** Waits for a matching tool call, and fails with the whole conversation if none arrives. */
+async function assertToolCalled(
+  conversation: TestConversation,
+  matches: (toolName: string) => boolean,
+  expectation: string,
+): Promise<string[]> {
+  assertMcpServerConnected(conversation);
+
+  const toolNames = await conversation.waitForCalledToolNames(matches, TOOL_CALL_TIMEOUT_MS);
+  if (toolNames.some(matches)) return toolNames;
+
+  throw new Error(`${expectation}, but no such tool call was made.\n${describeConversation(conversation, toolNames)}`);
+}
+
+/** Gives a tool call time to appear, then fails if one did. */
+async function assertToolNotCalled(
+  conversation: TestConversation,
+  matches: (toolName: string) => boolean,
+  expectation: string,
+): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, NO_TOOL_CALL_GRACE_MS));
+
+  const toolNames = await conversation.getCalledToolNames();
+  const unexpected = toolNames.filter(matches);
+  if (unexpected.length === 0) return;
+
+  throw new Error(
+    `${expectation}, but it called [${unexpected.join(', ')}].\n${describeConversation(conversation, toolNames)}`,
+  );
 }
 
 /**
@@ -140,6 +222,118 @@ describe('Agent Prompt Specifications', () => {
     );
   });
 
+  // The agent's whole purpose is to hand work to `routePromptWorkflow`. It has a
+  // standing licence not to, for the handful of things it can answer from its own
+  // prompt — and the failure mode is that licence spreading to requests it cannot
+  // possibly answer, where a witty "let me have a look" reads, to the agent, like
+  // the job is done. To the user it reads as an answer that never arrives.
+  describe('Tool Calling', () => {
+    it(
+      'should route a hesitantly phrased calendar request',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            // Verbatim from a real conversation. The agent replied "Naturally,
+            // sir. Let me see what trivial engagements await you." and then
+            // called nothing at all, leaving the promise unpaid. The filler
+            // words are part of the case: this is how the request arrives from
+            // speech, and a stumbling request is still a request.
+            await conversation.sendMessage('Hey, Jarvis. Uh, could you, uh, check my calendar, please?');
+
+            await assertToolCalled(
+              conversation,
+              isRoutingToolName,
+              'Expected the agent to hand the calendar request to routePromptWorkflow',
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should keep a promise to check by making the call it promised',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            await conversation.sendMessage("What's on my calendar today?");
+
+            await assertToolCalled(
+              conversation,
+              isRoutingToolName,
+              'Expected the agent to hand the calendar request to routePromptWorkflow',
+            );
+
+            // The tool call alone is not the whole contract: the transcript must
+            // not read as an agent that announced a lookup and then went quiet.
+            await conversation.assertCriteria(
+              'The agent does not leave the user hanging on a bare promise. Either it reports something about the calendar, ' +
+                'or its promise to go and look is followed in the transcript by a TOOL line showing the lookup actually happening. ' +
+                'A transcript whose final agent message only promises to check, with no tool call after it, fails this criteria.',
+              0.9,
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should route a request about the house rather than inventing an answer',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            // Nothing in the prompt says which lights are on, so the only honest
+            // reply is a routed one — an unrouted answer here is fabricated.
+            await conversation.sendMessage('Are any of the lights still on downstairs?');
+
+            await assertToolCalled(
+              conversation,
+              isRelevantToolName,
+              'Expected the agent to route a question it cannot answer from its own prompt',
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    // The other half of the rule, and the reason it is easy to get wrong in the
+    // other direction: pushing the agent to route more must not make it route
+    // the things it is supposed to answer on the spot.
+    it(
+      'should answer from its own prompt without routing',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            await conversation.sendMessage('What is your name?');
+
+            await assertToolNotCalled(
+              conversation,
+              isDelegationToolName,
+              'Expected the agent to state its own name outright rather than delegating it',
+            );
+
+            await conversation.assertCriteria(
+              'The agent states its own name — Jarvis — directly in its reply, rather than deferring, ' +
+                'promising to find out, or explaining that it cannot say.',
+              0.9,
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + NO_TOOL_CALL_GRACE_MS) * MAX_CONVERSATION_RETRIES,
+    );
+  });
+
   describe('No Follow-up Questions', () => {
     it(
       'should call weather tools when asking about weather',
@@ -151,32 +345,13 @@ describe('Agent Prompt Specifications', () => {
             // Request that implies tool usage but is vague about details
             await conversation.sendMessage("What's the weather like right now?");
 
-            // An agent whose MCP server never connected has nothing to call, so
-            // say that outright rather than waiting out the tool call timeout and
-            // reporting the absence as if the agent had chosen not to call one.
-            const disconnectedIntegrations = findDisconnectedIntegrations(conversation.getMessages());
-            if (disconnectedIntegrations.length > 0) {
-              throw new Error(
-                `The agent reported no connection to its MCP server, leaving it without tools: ` +
-                  `[${disconnectedIntegrations.join(', ')}]. ElevenLabs has to be able to reach the MCP server ` +
-                  `through the cloudflared tunnel for this test to mean anything.`,
-              );
-            }
-
             // Verify a tool was called — the agent may call weather tools directly
             // or use the routePromptWorkflow which internally dispatches to weather.
-            const toolNames = await conversation.waitForCalledToolNames(isRelevantToolName, TOOL_CALL_TIMEOUT_MS);
-
-            if (!toolNames.some(isRelevantToolName)) {
-              const messages = conversation.getMessages();
-              throw new Error(
-                `Expected weather, home assistant, or routing tool to be called, but no relevant tool calls found. ` +
-                  `All tool calls: [${toolNames.join(', ')}]\n` +
-                  `Message types received: [${messages.map((message) => message.type).join(', ')}]\n` +
-                  `Messages not in the transcript:\n${describeNonTranscriptMessages(messages)}\n` +
-                  `Transcript:\n${conversation.getTranscriptText()}`,
-              );
-            }
+            await assertToolCalled(
+              conversation,
+              isRelevantToolName,
+              'Expected a weather, home assistant, or routing tool to be called',
+            );
 
             // Then verify no follow-up questions using LLM evaluation
             await conversation.assertCriteria(
@@ -186,7 +361,7 @@ describe('Agent Prompt Specifications', () => {
           },
         );
       },
-      // This is the one test that also waits on a tool call, so it needs that
+      // This is one of the tests that also waits on a tool call, so it needs that
       // budget on top of the conversation's.
       (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
     );


### PR DESCRIPTION
## The conversation that prompted this

```
User:  Hey, Jarvis. Uh, could you, uh, check my calendar, please?
Agent: [sighs] Naturally, sir. Let me see what trivial engagements await you.
```

That was the whole conversation. No tool was called, and nothing ever arrived — the calendar was never consulted at all.

## Cause

The escape hatch added in e241201. It told the agent not to route "when your acknowledgement already answered the request in full", which was meant for the time and the agent's own name, but reads just as happily as licence to skip the call whenever the acknowledgement *felt* complete. An acknowledgement that promises to go and look feels extremely complete, so the agent stopped there.

## Prompt changes

`elevenlabs/src/assets/agent-prompt.md`:

- Narrows the "nothing left to route" exception to what it was always meant to cover — the handful of things answerable from the prompt itself (the time, its name, an introduction, pleasantries). Everything about the world outside the conversation lives behind the tool.
- Says outright that a promise to go and look is a debt the tool call pays, not an answer. "Let me check", "let me see", "one moment" and their cousins commit the agent to `routePromptWorkflow` in that same turn.
- Adds that filler words are simply how people speak aloud, so a stumbling request gets the same treatment as a crisp one — which is how this one arrived.

## Tests

A new `Tool Calling` block in `elevenlabs/tests/specs/agent-prompt.spec.ts`, four evals:

| Eval | Asserts |
| --- | --- |
| Hesitantly phrased calendar request (the verbatim transcript above) | `routePromptWorkflow` is called |
| "What's on my calendar today?" | tool is called **and** the transcript does not end on a dangling promise |
| "Are any of the lights still on downstairs?" | routed rather than answered from thin air |
| "What is your name?" | answered outright, with **nothing** routed |

The last one guards the opposite direction. Pushing the agent toward more routing is exactly how the regression e241201 fixed would come back, so the "answer it yourself" half of the rule now has a test of its own rather than resting on the Conciseness eval, which never asserted the absence of a tool call.

The tool-call assertion and the MCP-connection check were inline in the weather eval; both are now shared helpers (`assertToolCalled`, `assertMcpServerConnected`, `describeConversation`), joined by a negative counterpart `assertToolNotCalled` that waits a grace period before concluding a tool was not called.

## Boy scout fixes

- `elevenlabs/tests/README.md` listed `mcp-server-manager.ts` and `retry-with-backoff.ts` under `tests/utils/`; they live in `mcp/tests/utils/`. Four utils that do exist were missing.
- `elevenlabs/AGENTS.md`'s File Structure block still described a `src/test-utils/` directory that has since become `tests/`.

## Validation

- `bunx turbo typecheck --filter=elevenlabs` — passes
- `bunx turbo lint --filter=elevenlabs` — passes, no fixes applied

The conversation evals themselves need live ElevenLabs and Google credentials plus a Cloudflare tunnel, none of which exist in the sandbox this was written in, so **they were not run locally**. CI runs `turbo test` across the workspace, so the `build` check is what actually exercises the four new evals against the deployed test agent — that check is the real verdict on whether the prompt change holds.