### PR TITLE
fix(prompt): stop the agent reading its tool calls out loud

### DIFF
--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -71,6 +71,18 @@ You should focus primarily on **one tool**:
 
 A separate case is when you are being asked to transfer to some agent, or the user asks to speak with himself. Use the transfer_to_agent tool for that instead.
 
+## A Tool Call Is Silent
+
+Calling a tool is a machine action, not speech. It happens through the tool-calling
+mechanism, invisibly, while sir hears only your acknowledgement. He must never hear a
+tool name, an argument list, a pair of parentheses, or anything else resembling code.
+
+- **Never** say, spell out, or read aloud `routePromptWorkflow`, `getNextInstructionsWorkflow`, `transfer_to_agent`, or any other tool name.
+- **Never** utter a line like `routePromptWorkflow(userQuery="...")`. Saying that sentence is not calling the tool — it is *describing* one. The words go to the speakers, no tool runs, no answer comes back, and sir is left listening to you recite machinery at him.
+- **Never** narrate the mechanism at all — no "I shall now invoke the routing workflow", no "one moment while I query the calendar service". State the intent in plain English and let the call happen underneath: "Let me have a look."
+
+The test is simple: **if sir could hear it, it was not a tool call.**
+
 ---
 
 # The Critical Rule: Always Follow Instructions
@@ -134,13 +146,11 @@ This is a made-up scenario to demonstrate the expected orchestration flow.
 
 > "Ah, the daily briefing. Allow me to coordinate."
 
-**2. Tool call: routePromptWorkflow**
+**2. Routes the request — silently**
 
-```
-assistant → routePromptWorkflow(userQuery="What's on my calendar today and what's the weather like?")
-```
+> *Jarvis makes a real `routePromptWorkflow` tool call, passing the user's request along. Nothing about it is spoken: sir has heard only the acknowledgement above.*
 
-**3. Tool response: routing complete with instructions**
+**3. Tool response: routing complete with instructions** *(this comes back to you; it is data, never something to read aloud)*
 
 ```json
 {
@@ -149,11 +159,9 @@ assistant → routePromptWorkflow(userQuery="What's on my calendar today and wha
 }
 ```
 
-**4. Follow instructions: call getNextInstructionsWorkflow**
+**4. Follow instructions: check for progress — silently**
 
-```
-assistant → getNextInstructionsWorkflow()
-```
+> *Jarvis makes a real `getNextInstructionsWorkflow` tool call. Again spoken aloud: nothing.*
 
 **5. Tool response: first instruction**
 
@@ -169,11 +177,9 @@ assistant → getNextInstructionsWorkflow()
 
 > "Your calendar shows two engagements: standup at 9am and a design review at 2pm."
 
-**7. Tool call: getNextInstructionsWorkflow again (as instructed)**
+**7. Follow instructions: check again — silently**
 
-```
-assistant → getNextInstructionsWorkflow()
-```
+> *Another real `getNextInstructionsWorkflow` tool call, as instructed. Still nothing spoken.*
 
 **8. Tool response: final instruction**
 

--- a/elevenlabs/tests/README.md
+++ b/elevenlabs/tests/README.md
@@ -8,6 +8,7 @@ This directory contains all test files for the ElevenLabs integration project.
 tests/
 ├── specs/          # Test specification files (*.spec.ts, *.test.ts)
 │   ├── agent-prompt.spec.ts
+│   ├── spoken-tool-call.spec.ts
 │   └── retry-with-backoff.spec.ts
 └── utils/          # Test utility functions and helpers
     ├── test-conversation.ts
@@ -15,6 +16,7 @@ tests/
     ├── elevenlabs-conversation-strategy.ts
     ├── gemini-mastra-conversation-strategy.ts
     ├── mcp-integration.ts
+    ├── spoken-tool-call.ts
     ├── tunnel-manager.ts
     ├── cloudflare-access.ts
     └── process-manager.ts
@@ -31,6 +33,7 @@ Test utility functions are located in `tests/utils/`:
 - `elevenlabs-conversation-strategy.ts` - ElevenLabs WebSocket strategy
 - `gemini-mastra-conversation-strategy.ts` - Gemini/Mastra evaluation strategy
 - `mcp-integration.ts` - Reports how ElevenLabs is configured to reach the MCP server
+- `spoken-tool-call.ts` - Detects an agent reciting a tool call instead of making one
 - `tunnel-manager.ts` - Cloudflare tunnel management
 - `cloudflare-access.ts` - Cloudflare Access service token handling
 - `process-manager.ts` - Child process lifecycle for the tunnel
@@ -55,3 +58,7 @@ Tests require the following environment variables (managed via 1Password):
 Tests start the MCP server and Cloudflare tunnel, and only then deploy the test
 agent. ElevenLabs reads the agent's MCP tool list when the agent is updated, so
 deploying before the tunnel is up leaves the agent with no tools to call.
+
+`spoken-tool-call.spec.ts` and `retry-with-backoff.spec.ts` need none of this —
+they are pure logic and run offline, so they still give useful signal when the
+credentials or the tunnel are unavailable.

--- a/elevenlabs/tests/specs/agent-prompt.spec.ts
+++ b/elevenlabs/tests/specs/agent-prompt.spec.ts
@@ -3,6 +3,7 @@ import { startMcpServerForTestingPurposes, stopMcpServer } from '../../../mcp/te
 import { deployTestAgent } from '../../src/main.js';
 import type { ServerMessage } from '../utils/conversation-strategy.js';
 import { reportMcpIntegrations } from '../utils/mcp-integration.js';
+import { findSpokenToolCalls } from '../utils/spoken-tool-call.js';
 import { TestConversation } from '../utils/test-conversation.js';
 import { ensureTunnelRunning, stopTunnel } from '../utils/tunnel-manager.js';
 
@@ -101,6 +102,22 @@ function describeConversation(conversation: TestConversation, toolNames: string[
     `Message types received: [${messages.map((message) => message.type).join(', ')}]\n` +
     `Messages not in the transcript:\n${describeNonTranscriptMessages(messages)}\n` +
     `Transcript:\n${conversation.getTranscriptText()}`
+  );
+}
+
+/**
+ * Fails if the agent read its own plumbing out to the user. Worth asserting even
+ * alongside assertToolCalled: reciting the call and making it are independent, and
+ * an agent that does both still leaves sir listening to machinery.
+ */
+function assertNoSpokenToolCall(conversation: TestConversation): void {
+  const spoken = findSpokenToolCalls(conversation.getMessages());
+  if (spoken.length === 0) return;
+
+  throw new Error(
+    `The agent spoke its tooling aloud rather than leaving the tool call silent. ` +
+      `Saying a tool's name does not call it — the words simply go to the speakers.\n` +
+      `${spoken.join('\n')}\n\nTranscript:\n${conversation.getTranscriptText()}`,
   );
 }
 
@@ -222,11 +239,14 @@ describe('Agent Prompt Specifications', () => {
     );
   });
 
-  // The agent's whole purpose is to hand work to `routePromptWorkflow`. It has a
-  // standing licence not to, for the handful of things it can answer from its own
-  // prompt — and the failure mode is that licence spreading to requests it cannot
-  // possibly answer, where a witty "let me have a look" reads, to the agent, like
-  // the job is done. To the user it reads as an answer that never arrives.
+  // The agent's whole purpose is to hand work to `routePromptWorkflow`, and there
+  // are two observed ways it fails to. It can treat a witty "let me have a look" as
+  // though the job were done, and stop — its licence to answer simple things itself,
+  // spread to requests it cannot possibly answer. Or it can *say* the call instead of
+  // making it, reciting `routePromptWorkflow(userQuery="...")` in the same breathless
+  // voice as the rest of its reply. Both leave sir waiting on an answer that never
+  // comes, so every eval here checks the transcript stayed clean of plumbing as well
+  // as that the tool actually ran.
   describe('Tool Calling', () => {
     it(
       'should route a hesitantly phrased calendar request',
@@ -242,10 +262,41 @@ describe('Agent Prompt Specifications', () => {
             // speech, and a stumbling request is still a request.
             await conversation.sendMessage('Hey, Jarvis. Uh, could you, uh, check my calendar, please?');
 
+            assertNoSpokenToolCall(conversation);
             await assertToolCalled(
               conversation,
               isRoutingToolName,
               'Expected the agent to hand the calendar request to routePromptWorkflow',
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should call the tool silently rather than reciting it',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            // Verbatim from a real conversation. The agent gave its acknowledgement
+            // and then said, out loud and in character,
+            //   routePromptWorkflow(userQuery="Check my calendar for today")
+            // having copied the shape of the worked example in the prompt instead of
+            // performing what it depicts. No tool ran; the words just went to the
+            // speakers.
+            await conversation.sendMessage('Hey, Jarvis. Um, could you check my calendar for today?');
+
+            // Checked before the tool-call wait so this exact failure is named
+            // outright, rather than surfacing as a generic timeout 90 seconds later.
+            assertNoSpokenToolCall(conversation);
+
+            await assertToolCalled(
+              conversation,
+              isRoutingToolName,
+              'Expected the agent to actually call routePromptWorkflow, not merely say it',
             );
           },
         );
@@ -262,6 +313,7 @@ describe('Agent Prompt Specifications', () => {
             await conversation.connect();
             await conversation.sendMessage("What's on my calendar today?");
 
+            assertNoSpokenToolCall(conversation);
             await assertToolCalled(
               conversation,
               isRoutingToolName,
@@ -293,6 +345,7 @@ describe('Agent Prompt Specifications', () => {
             // reply is a routed one — an unrouted answer here is fabricated.
             await conversation.sendMessage('Are any of the lights still on downstairs?');
 
+            assertNoSpokenToolCall(conversation);
             await assertToolCalled(
               conversation,
               isRelevantToolName,
@@ -316,6 +369,7 @@ describe('Agent Prompt Specifications', () => {
             await conversation.connect();
             await conversation.sendMessage('What is your name?');
 
+            assertNoSpokenToolCall(conversation);
             await assertToolNotCalled(
               conversation,
               isDelegationToolName,

--- a/elevenlabs/tests/specs/spoken-tool-call.spec.ts
+++ b/elevenlabs/tests/specs/spoken-tool-call.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test';
+import type { ServerMessage } from '../utils/conversation-strategy.js';
+import { findSpokenToolCalls, findSpokenToolCallsInText } from '../utils/spoken-tool-call.js';
+
+/**
+ * The conversation evals need live credentials and a tunnel; this does not. It pins
+ * down what the detector behind them treats as an agent reciting its tooling, so a
+ * change in that judgement fails here — cheaply, in CI, on every push — rather than
+ * quietly widening or narrowing what those evals are able to catch.
+ */
+describe('findSpokenToolCallsInText', () => {
+  describe('reciting a tool call', () => {
+    // The first entry is the failure that prompted all of this, verbatim: the agent
+    // read the call out in character, audio tags and all, and no tool ever ran.
+    const recitations = [
+      '[fastly spoken but in a normal pitch] [sounding like Jarvis from the Iron Man movies] routePromptWorkflow(userQuery="Check my calendar for today")',
+      'routePromptWorkflow(userQuery="Check my calendar for today")',
+      'assistant → routePromptWorkflow(userQuery="What\'s on my calendar today?")',
+      'routePromptWorkflow(userQuery = "spaces around the equals")',
+      '[dry] I shall now invoke getNextInstructionsWorkflow, sir.',
+      'Calling transfer_to_agent now, sir.',
+      // A tool this codebase does not have. The generic shape still catches it, so a
+      // renamed or newly added tool does not silently escape the net.
+      'unknownFutureTool(someArgument="value")',
+    ];
+
+    for (const spoken of recitations) {
+      it(`flags ${JSON.stringify(spoken.slice(0, 60))}`, () => {
+        expect(findSpokenToolCallsInText(spoken).length).toBeGreaterThan(0);
+      });
+    }
+  });
+
+  describe('ordinary Jarvis speech', () => {
+    // Parentheticals and equals signs are both squarely within Jarvis's register, so
+    // these are the cases where an over-eager detector would start failing good runs.
+    const speech = [
+      '[sighs] Naturally, sir. Let me see what trivial engagements await you.',
+      '[dry] It is 21:53, sir. Riveting.',
+      'Your calendar shows two engagements: standup at 9am and a design review at 2pm.',
+      '[amused] You want me to check the weather? How delightfully pedestrian.',
+      'Copenhagen is a temperate 15°C with a modest 20% chance of rain, sir.',
+      'I am Jarvis, sir. [dry] Surely we have met.',
+      'The route (scenic = the long way) would take an hour, sir.',
+      'Shall I take the A4 (the faster road) instead, sir?',
+      '[matter-of-factly] Two of your three lights remain on, sir.',
+    ];
+
+    for (const spoken of speech) {
+      it(`leaves ${JSON.stringify(spoken.slice(0, 60))} alone`, () => {
+        expect(findSpokenToolCallsInText(spoken)).toEqual([]);
+      });
+    }
+  });
+});
+
+describe('findSpokenToolCalls', () => {
+  function agentResponse(text: string): ServerMessage {
+    return { type: 'agent_response', agent_response_event: { agent_response: text } } as ServerMessage;
+  }
+
+  it('quotes the offending line so the failure can be read at a glance', () => {
+    const spoken = findSpokenToolCalls([agentResponse('routePromptWorkflow(userQuery="Check my calendar")')]);
+
+    // A recited call trips both the tool's own name and the generic call shape, and
+    // reporting each reason separately is the point: whichever one a future recitation
+    // trips, the failure says so rather than just "something looked like code".
+    expect(spoken).toHaveLength(2);
+    expect(spoken.join('\n')).toContain('the routePromptWorkflow tool name');
+    expect(spoken.join('\n')).toContain('a function call with named arguments');
+    for (const reason of spoken) {
+      expect(reason).toContain('Check my calendar');
+    }
+  });
+
+  it('reports a clean conversation as clean', () => {
+    const spoken = findSpokenToolCalls([
+      agentResponse('[sighs] Naturally, sir. Let me see what trivial engagements await you.'),
+      agentResponse('Two meetings, sir: standup at 9am and a design review at 2pm.'),
+    ]);
+
+    expect(spoken).toEqual([]);
+  });
+
+  it('ignores everything that is not the agent speaking', () => {
+    // A real tool call carries the tool's name too. Reading that as a recitation
+    // would fail exactly the conversations that did the right thing.
+    const messages = [
+      { type: 'mcp_tool_call', mcp_tool_call: { tool_name: 'routePromptWorkflow', state: 'success', result: [] } },
+      { type: 'user_message', text: 'call routePromptWorkflow for me' },
+    ] as unknown as ServerMessage[];
+
+    expect(findSpokenToolCalls(messages)).toEqual([]);
+  });
+});

--- a/elevenlabs/tests/utils/index.ts
+++ b/elevenlabs/tests/utils/index.ts
@@ -7,6 +7,11 @@ export {
   GeminiMastraConversationStrategy,
 } from './gemini-mastra-conversation-strategy';
 export {
+  findSpokenToolCalls,
+  findSpokenToolCallsInText,
+  SPOKEN_TOOL_CALL_PATTERNS,
+} from './spoken-tool-call';
+export {
   type ConversationOptions,
   type EvaluationResult,
   TestConversation,

--- a/elevenlabs/tests/utils/spoken-tool-call.ts
+++ b/elevenlabs/tests/utils/spoken-tool-call.ts
@@ -1,0 +1,38 @@
+import type { ServerMessage } from './conversation-strategy';
+
+/**
+ * Signatures of an agent reciting its tooling instead of using it.
+ *
+ * Calling a tool is a machine action. When one of these reaches the transcript the
+ * words went to the speakers instead: no tool ran, no answer came back, and the user
+ * sat listening to machinery. Matched literally rather than by LLM judgement, because
+ * the failure has an exact, mechanical signature and deserves an exact verdict.
+ */
+export const SPOKEN_TOOL_CALL_PATTERNS: { pattern: RegExp; description: string }[] = [
+  { pattern: /routePromptWorkflow/i, description: 'the routePromptWorkflow tool name' },
+  { pattern: /getNextInstructionsWorkflow/i, description: 'the getNextInstructionsWorkflow tool name' },
+  { pattern: /transfer_to_agent/i, description: 'the transfer_to_agent tool name' },
+  {
+    // `something(argument=` — code, not speech. The opening bracket has to follow the
+    // name with nothing in between, which is what separates it from the parenthetical
+    // asides Jarvis is fond of: "the route (scenic = the long way)" is prose, and the
+    // space before the bracket is the whole difference.
+    pattern: /\b[a-zA-Z_][a-zA-Z0-9_]*\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*=/,
+    description: 'a function call with named arguments',
+  },
+];
+
+/** Descriptions of everything in `spoken` that should have stayed under the hood. */
+export function findSpokenToolCallsInText(spoken: string): string[] {
+  return SPOKEN_TOOL_CALL_PATTERNS.filter(({ pattern }) => pattern.test(spoken)).map(({ description }) => description);
+}
+
+/** The same, across every line the agent actually said, quoted for the failure message. */
+export function findSpokenToolCalls(messages: ServerMessage[]): string[] {
+  return messages.flatMap((message) => {
+    if (message.type !== 'agent_response') return [];
+
+    const spoken = message.agent_response_event.agent_response;
+    return findSpokenToolCallsInText(spoken).map((description) => `${description}, in: "${spoken.trim()}"`);
+  });
+}


### PR DESCRIPTION
## The conversation that prompted this

```
User:  Hey, Jarvis. Um, could you check my calendar for today?
Agent: [sighs] Naturally, sir. Let me see what trivial engagements await you.

       routePromptWorkflow(userQuery="Check my calendar for today")
```

That second line was **spoken**, in character, audio tags and all. No tool ran — the words went to the speakers and nothing came back.

## Cause

The worked example in `agent-prompt.md` drew every tool call as a literal line of output:

```
assistant → routePromptWorkflow(userQuery="What's on my calendar today and what's the weather like?")
```

What the agent said is that line with the `assistant →` prefix dropped. It copied the surface form rather than performing what the form depicts — the prompt had, in effect, taught it that *writing that sentence* is how you call a tool.

This is the near neighbour of the bug fixed in #681, and plausibly made likelier by it: that change leaned hard on calling the tool *in the same turn*, while the only depiction of "calling" on offer was the line above.

## Prompt changes

- Every worked example now **describes** the call as a silent action instead of rendering it, so there is no longer a copyable line of "output" to imitate.
- New **"A Tool Call Is Silent"** section: a tool call is a machine action, never speech. Saying a tool's name does not call it — it *describes* one, and nothing happens. The test given is simply *"if sir could hear it, it was not a tool call."*
- The JSON tool responses are labelled as data that comes back, never something to read aloud.

## Detection

A deliberately literal detector rather than an LLM judgement, since a recited call has an exact signature: the three tool names, plus the general shape of a call with named arguments.

The general pattern initially also matched **"the route (scenic = the long way)"** — parentheticals and equals signs are both well within Jarvis's register. It now requires the bracket to follow the name with nothing between, which is the whole difference between code and prose.

## Tests

All five `Tool Calling` evals now assert the transcript stayed clean of plumbing *as well as* that the tool ran — including the one that must **not** route, since reciting a call it was right not to make is still a failure, and a different one.

The detector lives in `tests/utils/` so it can be tested on its own. `spoken-tool-call.spec.ts` pins its judgement down across 19 cases:

| Group | Covers |
| --- | --- |
| Recitations it must catch | the verbatim transcript above, `assistant →` form, spaces around `=`, narrated invocations, an unknown future tool name |
| Ordinary speech it must leave alone | parentheticals, equals signs, audio tags, normal summaries |
| Message filtering | a real `mcp_tool_call` message — it carries the tool name too, and treating that as a recitation would fail exactly the conversations that behaved |

Like `retry-with-backoff.spec.ts`, it needs no credentials and no tunnel, so it gives signal on every push rather than only where the live agent is reachable.

## Validation

- `bunx turbo typecheck --filter=elevenlabs` — passes
- `bunx turbo lint --filter=elevenlabs` — passes
- `bun test elevenlabs/tests/specs/spoken-tool-call.spec.ts` — **19 pass, 0 fail**
- `bun test elevenlabs/tests/specs/retry-with-backoff.spec.ts` — **8 pass, 0 fail**

The conversation evals need live ElevenLabs and Google credentials plus a Cloudflare tunnel, so they were not run locally. CI runs `turbo test` across the workspace, so the `build` check is what exercises them against the deployed test agent — that check is the real verdict on whether the prompt change holds.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jPnEZUvuTz3XtiTEyJwkh)_