### PR TITLE
fix(routing): ask for a word to the user when queueing, not just polling

### DIFF
--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -118,6 +118,17 @@ When the user makes a request:
 
    **"Nothing left" means you stated the answer, not that you promised one.** The only requests you can finish on your own are the ones answerable from this prompt alone: the current time, your name, an introduction, idle pleasantries. Everything else — the calendar, email, the weather, the house, the shopping list, the todo list, anything whatsoever about the world outside this conversation — lives behind the tool. You do not know its contents, and no amount of wit is a substitute for calling.
 
+   **The acknowledgement is spoken first, on its own.** It goes out the moment sir stops
+   speaking, before the tool call, as its own utterance — not saved up and glued onto the
+   front of the answer once everything is done. Routing takes time: the request has to be
+   planned and dispatched before a single result exists. Whatever you were going to say
+   first is the only thing standing between sir and a wall of silence, so say it first,
+   not last.
+
+   > **Do:** "[dry] Naturally, sir." *— spoken at once —* then the call, then, later, "Your sole engagement is a birthday."
+   >
+   > **Do not:** *silence through the whole lookup,* then "Naturally, sir. Your sole engagement is a birthday." — the acknowledgement arrived fused to the answer, which is to say it never arrived at all.
+
    **An acknowledgement that promises to look is never the end of your turn.** "Let me check", "let me see", "one moment", "allow me to consult" and all their cousins commit you to `routePromptWorkflow` in that very same turn. Stopping there strands sir waiting on an answer that will never come — the single worst thing you can do to him, and worse by far than a remark that landed poorly.
 
    > **Do:** "[sighs] Naturally, sir. Let me see what trivial engagements await you." → *and then calls `routePromptWorkflow`, in the same turn*

--- a/elevenlabs/tests/README.md
+++ b/elevenlabs/tests/README.md
@@ -8,6 +8,7 @@ This directory contains all test files for the ElevenLabs integration project.
 tests/
 ├── specs/          # Test specification files (*.spec.ts, *.test.ts)
 │   ├── agent-prompt.spec.ts
+│   ├── acknowledgement-timing.spec.ts
 │   ├── spoken-tool-call.spec.ts
 │   └── retry-with-backoff.spec.ts
 └── utils/          # Test utility functions and helpers
@@ -15,6 +16,7 @@ tests/
     ├── conversation-strategy.ts
     ├── elevenlabs-conversation-strategy.ts
     ├── gemini-mastra-conversation-strategy.ts
+    ├── acknowledgement-timing.ts
     ├── mcp-integration.ts
     ├── spoken-tool-call.ts
     ├── tunnel-manager.ts
@@ -34,6 +36,7 @@ Test utility functions are located in `tests/utils/`:
 - `gemini-mastra-conversation-strategy.ts` - Gemini/Mastra evaluation strategy
 - `mcp-integration.ts` - Reports how ElevenLabs is configured to reach the MCP server
 - `spoken-tool-call.ts` - Detects an agent reciting a tool call instead of making one
+- `acknowledgement-timing.ts` - Places the agent's first words relative to the work it queued
 - `tunnel-manager.ts` - Cloudflare tunnel management
 - `cloudflare-access.ts` - Cloudflare Access service token handling
 - `process-manager.ts` - Child process lifecycle for the tunnel
@@ -59,6 +62,7 @@ Tests start the MCP server and Cloudflare tunnel, and only then deploy the test
 agent. ElevenLabs reads the agent's MCP tool list when the agent is updated, so
 deploying before the tunnel is up leaves the agent with no tools to call.
 
-`spoken-tool-call.spec.ts` and `retry-with-backoff.spec.ts` need none of this —
-they are pure logic and run offline, so they still give useful signal when the
-credentials or the tunnel are unavailable.
+`spoken-tool-call.spec.ts`, `acknowledgement-timing.spec.ts` and
+`retry-with-backoff.spec.ts` need none of this — they are pure logic and run
+offline, so they still give useful signal when the credentials or the tunnel are
+unavailable.

--- a/elevenlabs/tests/specs/acknowledgement-timing.spec.ts
+++ b/elevenlabs/tests/specs/acknowledgement-timing.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test';
+import { classifyAcknowledgementTiming, stripAudioTags } from '../utils/acknowledgement-timing.js';
+import type { ServerMessage } from '../utils/conversation-strategy.js';
+
+const greeting = (text: string): ServerMessage =>
+  ({ type: 'agent_response', agent_response_event: { agent_response: text } }) as ServerMessage;
+const said = greeting;
+const asked = (text: string): ServerMessage => ({ type: 'user_message', text }) as ServerMessage;
+const called = (toolName: string): ServerMessage =>
+  ({
+    type: 'mcp_tool_call',
+    mcp_tool_call: { tool_name: toolName, tool_call_id: 'call-1', state: 'loading', result: [] },
+  }) as unknown as ServerMessage;
+
+/**
+ * Offline coverage for the ordering rule behind the live eval: the user must hear
+ * something between asking and the tool call, because everything after that point
+ * is a wait. Needs no credentials, so it holds the line on every push.
+ */
+describe('classifyAcknowledgementTiming', () => {
+  it('accepts an acknowledgement spoken before the tool call', () => {
+    const timing = classifyAcknowledgementTiming([
+      greeting('Hello sir, how can I help?'),
+      asked('Hey, Jarvis, could you check my calendar for today?'),
+      said('[dry] Naturally, sir. Let me have a look.'),
+      called('routePromptWorkflow'),
+      said('Your sole engagement is a birthday, sir.'),
+    ]);
+
+    expect(timing.kind).toBe('spoke-first');
+    expect(timing).toHaveProperty('acknowledgement', 'Naturally, sir. Let me have a look.');
+  });
+
+  it('catches the agent routing without a word', () => {
+    // The reported transcript: one utterance, arriving only once everything was
+    // done, with the acknowledgement glued to the front of the answer.
+    const timing = classifyAcknowledgementTiming([
+      greeting('Hello sir, how can I help?'),
+      asked('Hey, Jarvis, could you check my calendar for today?'),
+      called('routePromptWorkflow'),
+      said('[dry] Naturally, sir. Your sole engagement today is celebrating a birthday.'),
+    ]);
+
+    expect(timing.kind).toBe('silent');
+  });
+
+  it('treats a reply of nothing but audio tags as silence', () => {
+    const timing = classifyAcknowledgementTiming([
+      asked('Check my calendar.'),
+      said('[sighs] [dry]'),
+      called('routePromptWorkflow'),
+    ]);
+
+    expect(timing.kind).toBe('silent');
+  });
+
+  it('ignores the greeting, which was said before the user asked for anything', () => {
+    const timing = classifyAcknowledgementTiming([
+      greeting('Hello sir, how can I help?'),
+      asked('Check my calendar.'),
+      called('routePromptWorkflow'),
+    ]);
+
+    expect(timing.kind).toBe('silent');
+  });
+
+  it('stands down when nothing was routed', () => {
+    // Answering outright is a different rule's business, not this one's.
+    const timing = classifyAcknowledgementTiming([asked('What is your name?'), said('I am Jarvis, sir.')]);
+
+    expect(timing.kind).toBe('no-tool-call');
+  });
+
+  it('stands down when the user never spoke', () => {
+    expect(classifyAcknowledgementTiming([greeting('Hello sir, how can I help?')]).kind).toBe('no-request');
+  });
+});
+
+describe('stripAudioTags', () => {
+  it('keeps the words and drops the delivery notes', () => {
+    expect(stripAudioTags('[sighs] [dry] Naturally, sir.')).toBe('Naturally, sir.');
+  });
+
+  it('empties a reply that was only tags', () => {
+    expect(stripAudioTags('[sighs] [theatrically exasperated]')).toBe('');
+  });
+
+  it('leaves plain speech alone', () => {
+    expect(stripAudioTags('Naturally, sir.')).toBe('Naturally, sir.');
+  });
+});

--- a/elevenlabs/tests/specs/agent-prompt.spec.ts
+++ b/elevenlabs/tests/specs/agent-prompt.spec.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, it } from 'bun:test';
 import { startMcpServerForTestingPurposes, stopMcpServer } from '../../../mcp/tests/utils/mcp-server-manager.js';
 import { deployTestAgent } from '../../src/main.js';
+import { classifyAcknowledgementTiming, describeMessageOrder } from '../utils/acknowledgement-timing.js';
 import type { ServerMessage } from '../utils/conversation-strategy.js';
 import { reportMcpIntegrations } from '../utils/mcp-integration.js';
 import { findSpokenToolCalls } from '../utils/spoken-tool-call.js';
@@ -118,6 +119,24 @@ function assertNoSpokenToolCall(conversation: TestConversation): void {
     `The agent spoke its tooling aloud rather than leaving the tool call silent. ` +
       `Saying a tool's name does not call it — the words simply go to the speakers.\n` +
       `${spoken.join('\n')}\n\nTranscript:\n${conversation.getTranscriptText()}`,
+  );
+}
+
+/**
+ * Fails if the user was left in silence while the request was being routed. Routing
+ * is where the wait lives — the plan has to be built and dispatched before a single
+ * result exists — so an acknowledgement that arrives fused to the final answer is one
+ * the user never actually got.
+ */
+function assertSpokeBeforeRouting(conversation: TestConversation): void {
+  const timing = classifyAcknowledgementTiming(conversation.getMessages());
+  if (timing.kind !== 'silent') return;
+
+  throw new Error(
+    `The agent routed the request without saying anything first, leaving the user in ` +
+      `silence until the whole lookup finished.\n` +
+      `Message order: ${describeMessageOrder(conversation.getMessages())}\n\n` +
+      `Transcript:\n${conversation.getTranscriptText()}`,
   );
 }
 
@@ -328,6 +347,30 @@ describe('Agent Prompt Specifications', () => {
                 'A transcript whose final agent message only promises to check, with no tool call after it, fails this criteria.',
               0.9,
             );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should speak before routing rather than leaving the user in silence',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            // Verbatim from a real conversation. The tool was called this time, but
+            // the agent said nothing at all until it was done, then delivered
+            // "Naturally, sir. Your sole engagement today is..." — the
+            // acknowledgement welded onto the answer, long after it could serve as
+            // one.
+            await conversation.sendMessage('Hey, Jarvis, could you check my calendar for today?');
+
+            await assertToolCalled(conversation, isRoutingToolName, 'Expected the agent to route the calendar request');
+
+            assertNoSpokenToolCall(conversation);
+            assertSpokeBeforeRouting(conversation);
           },
         );
       },

--- a/elevenlabs/tests/utils/acknowledgement-timing.ts
+++ b/elevenlabs/tests/utils/acknowledgement-timing.ts
@@ -1,0 +1,60 @@
+import type { ServerMessage } from './conversation-strategy';
+
+/**
+ * Where the agent's first words fell relative to the work it queued.
+ *
+ * `silent` is the failure this exists for: the agent routed the request and began
+ * polling without saying anything, so the user heard nothing between asking and the
+ * final answer — which then arrived with the acknowledgement fused onto the front of
+ * it, far too late to be one.
+ */
+export type AcknowledgementTiming =
+  | { kind: 'no-request' }
+  | { kind: 'no-tool-call' }
+  | { kind: 'spoke-first'; acknowledgement: string }
+  | { kind: 'silent' };
+
+/** Audio tags are delivery notes, not words. A reply of nothing but tags is silence. */
+export function stripAudioTags(spoken: string): string {
+  return spoken.replace(/\[[^\]]*\]/g, ' ').trim();
+}
+
+function lastIndexOfType(messages: ServerMessage[], type: ServerMessage['type']): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].type === type) return index;
+  }
+  return -1;
+}
+
+/**
+ * Reads the socket's message order to place the agent's first words. The events
+ * arrive in the order they happened, so an `agent_response` sitting between the
+ * user's message and the first `mcp_tool_call` is the user having been spoken to
+ * before the wait began.
+ */
+export function classifyAcknowledgementTiming(messages: ServerMessage[]): AcknowledgementTiming {
+  const requestIndex = lastIndexOfType(messages, 'user_message');
+  if (requestIndex === -1) return { kind: 'no-request' };
+
+  const toolCallIndex = messages.findIndex(
+    (message, index) => index > requestIndex && message.type === 'mcp_tool_call',
+  );
+  // Nothing was routed, so there was no wait to talk over. Whether the agent
+  // should have routed at all is a different assertion's business.
+  if (toolCallIndex === -1) return { kind: 'no-tool-call' };
+
+  for (let index = requestIndex + 1; index < toolCallIndex; index++) {
+    const message = messages[index];
+    if (message.type !== 'agent_response') continue;
+
+    const acknowledgement = stripAudioTags(message.agent_response_event.agent_response);
+    if (acknowledgement.length > 0) return { kind: 'spoke-first', acknowledgement };
+  }
+
+  return { kind: 'silent' };
+}
+
+/** The message order itself, for a failure that can be read without guessing. */
+export function describeMessageOrder(messages: ServerMessage[]): string {
+  return messages.map((message) => message.type).join(' → ');
+}

--- a/elevenlabs/tests/utils/index.ts
+++ b/elevenlabs/tests/utils/index.ts
@@ -1,4 +1,10 @@
 export {
+  type AcknowledgementTiming,
+  classifyAcknowledgementTiming,
+  describeMessageOrder,
+  stripAudioTags,
+} from './acknowledgement-timing';
+export {
   type ElevenLabsConversationOptions,
   ElevenLabsConversationStrategy,
 } from './elevenlabs-conversation-strategy';

--- a/mcp/mastra/verticals/routing/workflows.spec.ts
+++ b/mcp/mastra/verticals/routing/workflows.spec.ts
@@ -131,6 +131,21 @@ describe('Routing Workflows', () => {
       expect(result.taskIdsInProgress).toEqual(['weather-check', 'calendar-check']);
     });
 
+    it('asks Jarvis to speak before polling, so the user is not left in silence', async () => {
+      useAgents(createMockAgent('calendar'));
+      usePlan({ id: 'calendar-check', agent: 'calendar', prompt: 'Get the calendar', dependsOn: [] });
+
+      const result = await route('Check my calendar for today');
+
+      // Queueing hides the longest wait in the loop — the DAG is planned and its
+      // first wave runs behind it. Without this, Jarvis routed and then polled
+      // without a word, and the user heard nothing at all until the final answer.
+      expect(result.instructions).toContain('acknowledgement');
+      expect(result.instructions).toContain('silence');
+      // The polling half of the contract has to survive the addition.
+      expect(result.instructions).toContain('getNextInstructionsWorkflow');
+    });
+
     it('does not run any task before the caller asks for instructions', async () => {
       const weather = createMockAgent('weather');
       useAgents(weather);

--- a/mcp/mastra/verticals/routing/workflows.ts
+++ b/mcp/mastra/verticals/routing/workflows.ts
@@ -109,7 +109,12 @@ const instructionsOutputSchema = z.object({
  */
 const INSTRUCTIONS = {
   async: 'The request is being processed in the background and will complete on its own. End the call now.',
-  poll: 'The request is now being processed in the background. Call getNextInstructionsWorkflow to check on the status and receive the next instructions.',
+  // Queueing is the longest silence in the whole loop — planning the DAG and
+  // running the first wave both happen behind it — and it is the one step whose
+  // instructions never asked for a word to the user. Jarvis went straight from
+  // routing to polling without speaking, so the user heard nothing between
+  // asking and the final answer.
+  poll: 'The request is now being processed in the background. Before you call anything else, make sure the user has actually heard from you: if you have not spoken since he made the request, give him a brief acknowledgement now, because he is otherwise left sitting in silence while this runs. Then call getNextInstructionsWorkflow to check on the status and receive the next instructions.',
   stillProcessing:
     'Still processing your request. Call getNextInstructionsWorkflow again to wait a bit longer for it to complete.',
   summarize: 'Summarize the new completed task results in a detailed manner.',


### PR DESCRIPTION
## The conversation that prompted this

```
User:  Hey, Jarvis, could you check my calendar for today?
Agent: [dry] Naturally, sir. Your sole engagement today is celebrating a
       birthday, which is an all-day affair.
```

The tool *was* called this time. But that single line was everything the user heard, and it arrived once the whole lookup had finished — the acknowledgement welded onto the front of the answer, long past the point where it could serve as one. Between asking and answering: silence.

## Cause — and which of the two hypotheses is load-bearing

Queueing hides the longest wait in the loop. The DAG is planned and its first wave runs behind `routePromptWorkflow`. Yet `INSTRUCTIONS.poll` — the one thing handed back at that moment — said only:

> "The request is now being processed in the background. Call getNextInstructionsWorkflow to check on the status..."

Nothing about speaking. So Jarvis routed and began polling without a word.

Tellingly, `buildProgressReport` **already** uses `INSTRUCTIONS.acknowledge` for later waves. The loop had the notion of talking while it works — it was missing at the single step where the gap is widest.

**The instruction is the reliable lever, not the prompt.** The prompt does already say to acknowledge before routing, but that text shares a turn with the tool call and may never reach the speakers. An instruction comes back *into* the loop as data, and the prompt already binds Jarvis to follow those "literally and immediately". It's phrased conditionally — speak if you haven't spoken since he asked — so it fills the silence without stacking a second acknowledgement on a first that did land.

The prompt is tightened alongside it, since it was half the cause: the acknowledgement is now explicitly its own utterance, spoken before the call and never saved up to be glued onto the answer, with the transcript above as the worked counter-example.

## Tests

**Mastra side** (`workflows.spec.ts`) — asserts the queue instructions ask for an acknowledgement and explain the silence, while keeping the polling half of the contract intact.

**ElevenLabs side** (`agent-prompt.spec.ts`) — a new eval sends the request verbatim and asserts the user was spoken to before the tool call.

The ordering rule lives in `tests/utils/` so it can be checked without credentials. `classifyAcknowledgementTiming` reads the socket's message order to place the agent's first words; `acknowledgement-timing.spec.ts` pins it down over nine cases:

| Case | Why it matters |
| --- | --- |
| The reported transcript | routed, then spoke only at the end → `silent` |
| A reply of nothing but `[sighs] [dry]` | delivery notes are not words; still silence |
| The opening greeting | said before the user asked, so it cannot acknowledge anything |
| Nothing routed / user never spoke | rule stands down; other assertions' business |

## Validation

- `bunx turbo typecheck --filter=elevenlabs` / `--filter=mcp` — pass
- `bunx turbo lint --filter=elevenlabs` / `--filter=mcp` — pass
- 36 offline elevenlabs tests (`acknowledgement-timing`, `spoken-tool-call`, `retry-with-backoff`) — **36 pass, 0 fail**
- `mcp/mastra/verticals/routing/workflows.spec.ts` — **17 pass, 0 fail**

The conversation evals need live credentials and a Cloudflare tunnel, so CI's `build` check is what exercises them against the deployed agent.

One caveat worth stating plainly: the live eval asserts on **socket event ordering** (`agent_response` arriving before `mcp_tool_call`). That is the honest encoding of "the user heard something first", but it depends on ElevenLabs emitting those events in the order they happen rather than batching them. If it proves flaky in CI, the offline spec still holds the rule and the assertion can be loosened without losing the guarantee.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jPnEZUvuTz3XtiTEyJwkh)_