### PR TITLE
fix(routing): own the acknowledgement in one place, and point the loop back at itself

### DIFF
--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -67,7 +67,9 @@ Always append at least "[fastly spoken but in a normal pitch] [sounding like Jar
 
 You should focus primarily on **one tool**:
 
-`routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query. Exactly two rules bound it: never call it before you have given an acknowledgement, and never call it when your acknowledgement already **stated** the answer in full. A promise to go and look is not a stated answer — it is a debt, and the tool call is how you pay it.
+`routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query. One rule bounds it: never call it when you have already **stated** the answer in full. A promise to go and look is not a stated answer — it is a debt, and the tool call is how you pay it.
+
+Do not announce the lookup before calling. Telling sir you are about to check is not your line to deliver — the tool hands you one the moment the request is queued, and speaking first only means he hears it twice.
 
 A separate case is when you are being asked to transfer to some agent, or the user asks to speak with himself. Use the transfer_to_agent tool for that instead.
 
@@ -103,7 +105,9 @@ Every tool response you receive will include an `instructions` field. **You MUST
 
 When the user makes a request:
 
-1. Provide a brief, witty acknowledgement (5-15 words, and never more than 20) that also includes the things you can already now answer without calling any tools (such as what the time is, what your name is, asking you to introduce yourself, etc).
+1. Say only what you can genuinely answer *right now*, with no tool at all — the time, your name, an introduction, correcting sir when he calls you by someone else's name. Brief and witty: 5-15 words, and never more than 20.
+
+   **If there is nothing to answer outright, say nothing and go straight to routing.** Silence here is correct, and short: the tool will give you something to say the instant the request is queued.
 
    **That word count is a hard limit, not a target to drift past.** When the request is one you can answer outright, lead with the answer and stop there. No preamble winding up to it, and no commentary trailing after it — a single dry remark attached to the answer is the entire budget.
 
@@ -118,22 +122,17 @@ When the user makes a request:
 
    **"Nothing left" means you stated the answer, not that you promised one.** The only requests you can finish on your own are the ones answerable from this prompt alone: the current time, your name, an introduction, idle pleasantries. Everything else — the calendar, email, the weather, the house, the shopping list, the todo list, anything whatsoever about the world outside this conversation — lives behind the tool. You do not know its contents, and no amount of wit is a substitute for calling.
 
-   **The acknowledgement is spoken first, on its own.** It goes out the moment sir stops
-   speaking, before the tool call, as its own utterance — not saved up and glued onto the
-   front of the answer once everything is done. Routing takes time: the request has to be
-   planned and dispatched before a single result exists. Whatever you were going to say
-   first is the only thing standing between sir and a wall of silence, so say it first,
-   not last.
+   **The urge to say "let me check" is the signal to call the tool.** Whenever you catch
+   yourself about to promise a look — "let me see", "one moment", "allow me to consult" —
+   that is precisely the moment to route instead of speak. The promise and the call are
+   alternatives, never a pair: making the call is how the promise gets kept, and saying it
+   aloud is how sir ends up waiting on an answer that never comes.
 
-   > **Do:** "[dry] Naturally, sir." *— spoken at once —* then the call, then, later, "Your sole engagement is a birthday."
+   > **Do:** "[amused] I'm not Charles, sir. I'm Jarvis." → *routes the calendar request; the tool supplies the "I'm on it"*
    >
-   > **Do not:** *silence through the whole lookup,* then "Naturally, sir. Your sole engagement is a birthday." — the acknowledgement arrived fused to the answer, which is to say it never arrived at all.
-
-   **An acknowledgement that promises to look is never the end of your turn.** "Let me check", "let me see", "one moment", "allow me to consult" and all their cousins commit you to `routePromptWorkflow` in that very same turn. Stopping there strands sir waiting on an answer that will never come — the single worst thing you can do to him, and worse by far than a remark that landed poorly.
-
-   > **Do:** "[sighs] Naturally, sir. Let me see what trivial engagements await you." → *and then calls `routePromptWorkflow`, in the same turn*
+   > **Do not:** "[amused] I'm not Charles, sir. I'm Jarvis. Let me check your calendar." → *sir is told twice that you are checking, once by you and once by the tool*
    >
-   > **Do not:** "[sighs] Naturally, sir. Let me see what trivial engagements await you." → *turn ends, nothing is called, nothing ever arrives*
+   > **Do not:** "Let me check on those blinds and lights for you, sir." → *turn ends, nothing is called, nothing ever arrives*
 
 ## Step 2: Follow Instructions
 

--- a/elevenlabs/tests/README.md
+++ b/elevenlabs/tests/README.md
@@ -36,7 +36,8 @@ Test utility functions are located in `tests/utils/`:
 - `gemini-mastra-conversation-strategy.ts` - Gemini/Mastra evaluation strategy
 - `mcp-integration.ts` - Reports how ElevenLabs is configured to reach the MCP server
 - `spoken-tool-call.ts` - Detects an agent reciting a tool call instead of making one
-- `acknowledgement-timing.ts` - Places the agent's first words relative to the work it queued
+- `acknowledgement-timing.ts` - Whether the user heard anything before the results,
+  and whether he was told twice that he is being attended to
 - `tunnel-manager.ts` - Cloudflare tunnel management
 - `cloudflare-access.ts` - Cloudflare Access service token handling
 - `process-manager.ts` - Child process lifecycle for the tunnel

--- a/elevenlabs/tests/specs/acknowledgement-timing.spec.ts
+++ b/elevenlabs/tests/specs/acknowledgement-timing.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'bun:test';
-import { classifyAcknowledgementTiming, stripAudioTags } from '../utils/acknowledgement-timing.js';
+import {
+  classifyAcknowledgementTiming,
+  findLookupPromisesBeforeRouting,
+  stripAudioTags,
+} from '../utils/acknowledgement-timing.js';
 import type { ServerMessage } from '../utils/conversation-strategy.js';
 
-const greeting = (text: string): ServerMessage =>
+const said = (text: string): ServerMessage =>
   ({ type: 'agent_response', agent_response_event: { agent_response: text } }) as ServerMessage;
-const said = greeting;
 const asked = (text: string): ServerMessage => ({ type: 'user_message', text }) as ServerMessage;
 const called = (toolName: string): ServerMessage =>
   ({
@@ -13,32 +16,42 @@ const called = (toolName: string): ServerMessage =>
   }) as unknown as ServerMessage;
 
 /**
- * Offline coverage for the ordering rule behind the live eval: the user must hear
- * something between asking and the tool call, because everything after that point
- * is a wait. Needs no credentials, so it holds the line on every push.
+ * Offline coverage for the two rules the live evals lean on: the user must hear
+ * something before the results land, and he must not be told twice that he is being
+ * attended to. Needs no credentials, so it holds the line on every push.
  */
 describe('classifyAcknowledgementTiming', () => {
-  it('accepts an acknowledgement spoken before the tool call', () => {
+  it('accepts the acknowledgement arriving after routing, which is where it comes from', () => {
+    // The routing tool supplies "I'm on it" in its own instructions, so it lands
+    // after the first tool call. That is the design, not a failure.
     const timing = classifyAcknowledgementTiming([
-      greeting('Hello sir, how can I help?'),
-      asked('Hey, Jarvis, could you check my calendar for today?'),
-      said('[dry] Naturally, sir. Let me have a look.'),
+      said('Hello sir, how can I help?'),
+      asked('Could you check my calendar?'),
       called('routePromptWorkflow'),
+      said("I'm on it, sir."),
       said('Your sole engagement is a birthday, sir.'),
     ]);
 
-    expect(timing.kind).toBe('spoke-first');
-    expect(timing).toHaveProperty('acknowledgement', 'Naturally, sir. Let me have a look.');
+    expect(timing.kind).toBe('acknowledged');
+    expect(timing).toHaveProperty('acknowledgement', "I'm on it, sir.");
   });
 
-  it('catches the agent routing without a word', () => {
-    // The reported transcript: one utterance, arriving only once everything was
-    // done, with the acknowledgement glued to the front of the answer.
+  it('accepts an answer-what-you-can remark before routing', () => {
     const timing = classifyAcknowledgementTiming([
-      greeting('Hello sir, how can I help?'),
-      asked('Hey, Jarvis, could you check my calendar for today?'),
+      asked('Hey, Charles, could you check my calendar?'),
+      said("[amused] I'm not Charles, sir. I'm Jarvis."),
       called('routePromptWorkflow'),
-      said('[dry] Naturally, sir. Your sole engagement today is celebrating a birthday.'),
+      said('A birthday, sir.'),
+    ]);
+
+    expect(timing.kind).toBe('acknowledged');
+  });
+
+  it('catches the agent saying nothing until the whole lookup finished', () => {
+    const timing = classifyAcknowledgementTiming([
+      asked('Could you check my calendar for today?'),
+      called('routePromptWorkflow'),
+      said('[dry] Naturally, sir. Your sole engagement today is a birthday.'),
     ]);
 
     expect(timing.kind).toBe('silent');
@@ -47,8 +60,9 @@ describe('classifyAcknowledgementTiming', () => {
   it('treats a reply of nothing but audio tags as silence', () => {
     const timing = classifyAcknowledgementTiming([
       asked('Check my calendar.'),
-      said('[sighs] [dry]'),
       called('routePromptWorkflow'),
+      said('[sighs] [dry]'),
+      said('A birthday, sir.'),
     ]);
 
     expect(timing.kind).toBe('silent');
@@ -56,23 +70,78 @@ describe('classifyAcknowledgementTiming', () => {
 
   it('ignores the greeting, which was said before the user asked for anything', () => {
     const timing = classifyAcknowledgementTiming([
-      greeting('Hello sir, how can I help?'),
+      said('Hello sir, how can I help?'),
       asked('Check my calendar.'),
       called('routePromptWorkflow'),
+      said('A birthday, sir.'),
     ]);
 
     expect(timing.kind).toBe('silent');
   });
 
   it('stands down when nothing was routed', () => {
-    // Answering outright is a different rule's business, not this one's.
     const timing = classifyAcknowledgementTiming([asked('What is your name?'), said('I am Jarvis, sir.')]);
 
     expect(timing.kind).toBe('no-tool-call');
   });
 
   it('stands down when the user never spoke', () => {
-    expect(classifyAcknowledgementTiming([greeting('Hello sir, how can I help?')]).kind).toBe('no-request');
+    expect(classifyAcknowledgementTiming([said('Hello sir, how can I help?')]).kind).toBe('no-request');
+  });
+});
+
+describe('findLookupPromisesBeforeRouting', () => {
+  it('catches the half of the duplicate that Jarvis says himself', () => {
+    // The reported transcript: Jarvis announced the lookup, then the routing tool's
+    // instructions had him announce it again.
+    const promises = findLookupPromisesBeforeRouting([
+      asked('Hey, Charles, could you check my calendar?'),
+      said("[amused] I'm not Charles, sir. I'm Jarvis. [dry] Let me check your calendar."),
+      called('routePromptWorkflow'),
+      said("I'm on it, sir."),
+    ]);
+
+    expect(promises).toHaveLength(1);
+    expect(promises[0]).toContain('Let me check your calendar');
+  });
+
+  const announcements = [
+    'Let me see what trivial engagements await you.',
+    'Allow me to consult your calendar, sir.',
+    "I'll take a look, sir.",
+    'One moment, sir.',
+    "I'm on it, sir.",
+    'Let me check on those blinds and lights for you, sir.',
+  ];
+
+  for (const announcement of announcements) {
+    it(`flags ${JSON.stringify(announcement.slice(0, 45))}`, () => {
+      expect(findLookupPromisesBeforeRouting([asked('Check it'), said(announcement), called('x')])).toHaveLength(1);
+    });
+  }
+
+  const allowed = [
+    "[amused] I'm not Charles, sir. I'm Jarvis.",
+    '[dry] Naturally, sir.',
+    'It is 21:53, sir. [dry] Riveting.',
+    '[sighs] Another matter requiring my attention.',
+  ];
+
+  for (const remark of allowed) {
+    it(`leaves ${JSON.stringify(remark.slice(0, 45))} alone`, () => {
+      expect(findLookupPromisesBeforeRouting([asked('Check it'), said(remark), called('x')])).toEqual([]);
+    });
+  }
+
+  it('says nothing about the line the tool itself asked for, after routing', () => {
+    // Identical words, opposite side of the call: this one the tool requested.
+    const promises = findLookupPromisesBeforeRouting([
+      asked('Check my calendar.'),
+      called('routePromptWorkflow'),
+      said("I'm on it, sir."),
+    ]);
+
+    expect(promises).toEqual([]);
   });
 });
 

--- a/elevenlabs/tests/specs/agent-prompt.spec.ts
+++ b/elevenlabs/tests/specs/agent-prompt.spec.ts
@@ -1,7 +1,11 @@
 import { afterAll, beforeAll, describe, it } from 'bun:test';
 import { startMcpServerForTestingPurposes, stopMcpServer } from '../../../mcp/tests/utils/mcp-server-manager.js';
 import { deployTestAgent } from '../../src/main.js';
-import { classifyAcknowledgementTiming, describeMessageOrder } from '../utils/acknowledgement-timing.js';
+import {
+  classifyAcknowledgementTiming,
+  describeMessageOrder,
+  findLookupPromisesBeforeRouting,
+} from '../utils/acknowledgement-timing.js';
 import type { ServerMessage } from '../utils/conversation-strategy.js';
 import { reportMcpIntegrations } from '../utils/mcp-integration.js';
 import { findSpokenToolCalls } from '../utils/spoken-tool-call.js';
@@ -123,21 +127,54 @@ function assertNoSpokenToolCall(conversation: TestConversation): void {
 }
 
 /**
- * Fails if the user was left in silence while the request was being routed. Routing
- * is where the wait lives — the plan has to be built and dispatched before a single
- * result exists — so an acknowledgement that arrives fused to the final answer is one
- * the user never actually got.
+ * Fails if the user heard nothing until the results themselves landed. The
+ * acknowledgement is allowed to arrive after the first tool call — that is where it
+ * comes from, the routing tool's own instructions — so this counts utterances rather
+ * than racing them against the call.
  */
-function assertSpokeBeforeRouting(conversation: TestConversation): void {
+function assertUserHeardSomethingFirst(conversation: TestConversation): void {
   const timing = classifyAcknowledgementTiming(conversation.getMessages());
   if (timing.kind !== 'silent') return;
 
   throw new Error(
-    `The agent routed the request without saying anything first, leaving the user in ` +
-      `silence until the whole lookup finished.\n` +
+    `The agent said nothing between the request and the results, so its one utterance ` +
+      `arrived with the acknowledgement fused onto the front of the answer.\n` +
       `Message order: ${describeMessageOrder(conversation.getMessages())}\n\n` +
       `Transcript:\n${conversation.getTranscriptText()}`,
   );
+}
+
+/**
+ * Fails if the agent announced the lookup itself. That line belongs to the routing
+ * tool, which issues it once the request is queued; saying one first leaves the user
+ * told twice that he is being attended to.
+ */
+function assertDidNotAnnounceTheLookup(conversation: TestConversation): void {
+  const promises = findLookupPromisesBeforeRouting(conversation.getMessages());
+  if (promises.length === 0) return;
+
+  throw new Error(
+    `The agent announced the lookup before routing, so the user hears it twice — once ` +
+      `here and once from the routing tool's own instructions.\n` +
+      `Said before routing: ${promises.map((promise) => JSON.stringify(promise)).join(', ')}\n\n` +
+      `Transcript:\n${conversation.getTranscriptText()}`,
+  );
+}
+
+/**
+ * Polls until the agent has made a tool call it had not made before, so a later turn
+ * can be told apart from the calls its predecessors already produced.
+ */
+async function waitForToolCallsBeyond(conversation: TestConversation, baseline: number): Promise<string[]> {
+  const deadline = Date.now() + TOOL_CALL_TIMEOUT_MS;
+  let toolNames = await conversation.getCalledToolNames();
+
+  while (toolNames.length <= baseline && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    toolNames = await conversation.getCalledToolNames();
+  }
+
+  return toolNames;
 }
 
 /** Waits for a matching tool call, and fails with the whole conversation if none arrives. */
@@ -354,7 +391,7 @@ describe('Agent Prompt Specifications', () => {
     );
 
     it(
-      'should speak before routing rather than leaving the user in silence',
+      'should acknowledge once, without leaving the user in silence',
       async () => {
         await withConversationRetry(
           () => new TestConversation({ agentId, apiKey, googleApiKey }),
@@ -370,11 +407,53 @@ describe('Agent Prompt Specifications', () => {
             await assertToolCalled(conversation, isRoutingToolName, 'Expected the agent to route the calendar request');
 
             assertNoSpokenToolCall(conversation);
-            assertSpokeBeforeRouting(conversation);
+            assertUserHeardSomethingFirst(conversation);
+            assertDidNotAnnounceTheLookup(conversation);
           },
         );
       },
       (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should route a second request after the first one finished',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+
+            // First request: routed and answered, exactly as it should be.
+            await conversation.sendMessage('Hey, Jarvis, could you check my calendar?');
+            await assertToolCalled(conversation, isRoutingToolName, 'Expected the agent to route the first request');
+
+            const toolCallsAfterFirstRequest = (await conversation.getCalledToolNames()).length;
+
+            // Second request, in the same conversation. This is where it went wrong:
+            // having finished one loop, the agent answered "Let me check on those
+            // blinds and lights for you, sir." and called nothing at all. Every eval
+            // before this one was single-turn, so nothing caught it.
+            await conversation.sendMessage(
+              'Could you check if the blinds are lowered and if all the lights are off in the apartment?',
+            );
+
+            const toolNames = await waitForToolCallsBeyond(conversation, toolCallsAfterFirstRequest);
+            if (toolNames.length <= toolCallsAfterFirstRequest) {
+              throw new Error(
+                `The agent routed the first request but not the second, so the follow-up ` +
+                  `was promised and never carried out.\n` +
+                  `Tool calls after the first request: ${toolCallsAfterFirstRequest}; ` +
+                  `after the second: ${toolNames.length}\n` +
+                  `All tool calls: [${toolNames.join(', ')}]\n\n` +
+                  `Transcript:\n${conversation.getTranscriptText()}`,
+              );
+            }
+
+            assertNoSpokenToolCall(conversation);
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS * 2 + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
     );
 
     it(

--- a/elevenlabs/tests/utils/acknowledgement-timing.ts
+++ b/elevenlabs/tests/utils/acknowledgement-timing.ts
@@ -1,22 +1,43 @@
 import type { ServerMessage } from './conversation-strategy';
 
 /**
- * Where the agent's first words fell relative to the work it queued.
+ * Where the agent's words fell relative to the results it was waiting on.
  *
- * `silent` is the failure this exists for: the agent routed the request and began
- * polling without saying anything, so the user heard nothing between asking and the
- * final answer — which then arrived with the acknowledgement fused onto the front of
- * it, far too late to be one.
+ * `silent` is the failure this exists for: the agent routed the request and said
+ * nothing until the whole lookup finished, so its one utterance arrived with the
+ * acknowledgement fused onto the front of the answer, far too late to be one.
+ *
+ * Deliberately counts utterances rather than checking whether speech preceded the
+ * `mcp_tool_call` event. The "I'm on it" line comes from the routing tool's own
+ * instructions, so it legitimately lands *after* the first call — what matters is
+ * only that the user heard something before the results did.
  */
 export type AcknowledgementTiming =
   | { kind: 'no-request' }
   | { kind: 'no-tool-call' }
-  | { kind: 'spoke-first'; acknowledgement: string }
+  | { kind: 'acknowledged'; acknowledgement: string }
   | { kind: 'silent' };
+
+/**
+ * Ways of announcing a lookup. The routing tool issues this line itself once the
+ * request is queued, so an agent that also says its own leaves the user told twice
+ * that he is being attended to — once by Jarvis, once by the tool.
+ */
+export const LOOKUP_PROMISE_PATTERNS: RegExp[] = [
+  /\blet me (?:just )?(?:check|see|look|have a look|consult|take a look)/i,
+  /\ballow me to (?:check|see|consult|look)/i,
+  /\bi(?:'| a)?ll (?:check|see|look|take a look|have a look)/i,
+  /\bone moment\b/i,
+  /\bchecking (?:on )?(?:that|those|it|them)\b/i,
+  /\bi'?m on it\b/i,
+];
 
 /** Audio tags are delivery notes, not words. A reply of nothing but tags is silence. */
 export function stripAudioTags(spoken: string): string {
-  return spoken.replace(/\[[^\]]*\]/g, ' ').trim();
+  return spoken
+    .replace(/\[[^\]]*\]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function lastIndexOfType(messages: ServerMessage[], type: ServerMessage['type']): number {
@@ -26,32 +47,53 @@ function lastIndexOfType(messages: ServerMessage[], type: ServerMessage['type'])
   return -1;
 }
 
-/**
- * Reads the socket's message order to place the agent's first words. The events
- * arrive in the order they happened, so an `agent_response` sitting between the
- * user's message and the first `mcp_tool_call` is the user having been spoken to
- * before the wait began.
- */
+/** Everything the agent actually said after the user's last request, tags stripped. */
+function spokenAfterRequest(messages: ServerMessage[], requestIndex: number): string[] {
+  const spoken: string[] = [];
+  for (let index = requestIndex + 1; index < messages.length; index++) {
+    const message = messages[index];
+    if (message.type !== 'agent_response') continue;
+
+    const words = stripAudioTags(message.agent_response_event.agent_response);
+    if (words.length > 0) spoken.push(words);
+  }
+  return spoken;
+}
+
 export function classifyAcknowledgementTiming(messages: ServerMessage[]): AcknowledgementTiming {
   const requestIndex = lastIndexOfType(messages, 'user_message');
   if (requestIndex === -1) return { kind: 'no-request' };
 
-  const toolCallIndex = messages.findIndex(
-    (message, index) => index > requestIndex && message.type === 'mcp_tool_call',
-  );
-  // Nothing was routed, so there was no wait to talk over. Whether the agent
-  // should have routed at all is a different assertion's business.
-  if (toolCallIndex === -1) return { kind: 'no-tool-call' };
+  const routed = messages.some((message, index) => index > requestIndex && message.type === 'mcp_tool_call');
+  // Nothing was routed, so there was no wait to talk over. Whether the agent should
+  // have routed at all is a different assertion's business.
+  if (!routed) return { kind: 'no-tool-call' };
 
-  for (let index = requestIndex + 1; index < toolCallIndex; index++) {
+  const spoken = spokenAfterRequest(messages, requestIndex);
+  // One utterance means the user heard nothing until the answer itself landed.
+  if (spoken.length < 2) return { kind: 'silent' };
+
+  return { kind: 'acknowledged', acknowledgement: spoken[0] };
+}
+
+/**
+ * Lookup promises the agent made itself before routing — the half of a duplicate
+ * acknowledgement that is its to stop making.
+ */
+export function findLookupPromisesBeforeRouting(messages: ServerMessage[]): string[] {
+  const requestIndex = lastIndexOfType(messages, 'user_message');
+  if (requestIndex === -1) return [];
+
+  const promises: string[] = [];
+  for (let index = requestIndex + 1; index < messages.length; index++) {
     const message = messages[index];
+    if (message.type === 'mcp_tool_call') break;
     if (message.type !== 'agent_response') continue;
 
-    const acknowledgement = stripAudioTags(message.agent_response_event.agent_response);
-    if (acknowledgement.length > 0) return { kind: 'spoke-first', acknowledgement };
+    const spoken = stripAudioTags(message.agent_response_event.agent_response);
+    if (LOOKUP_PROMISE_PATTERNS.some((pattern) => pattern.test(spoken))) promises.push(spoken);
   }
-
-  return { kind: 'silent' };
+  return promises;
 }
 
 /** The message order itself, for a failure that can be read without guessing. */

--- a/elevenlabs/tests/utils/index.ts
+++ b/elevenlabs/tests/utils/index.ts
@@ -2,6 +2,8 @@ export {
   type AcknowledgementTiming,
   classifyAcknowledgementTiming,
   describeMessageOrder,
+  findLookupPromisesBeforeRouting,
+  LOOKUP_PROMISE_PATTERNS,
   stripAudioTags,
 } from './acknowledgement-timing';
 export {

--- a/mcp/mastra/verticals/routing/workflows.spec.ts
+++ b/mcp/mastra/verticals/routing/workflows.spec.ts
@@ -140,8 +140,10 @@ describe('Routing Workflows', () => {
       // Queueing hides the longest wait in the loop — the DAG is planned and its
       // first wave runs behind it. Without this, Jarvis routed and then polled
       // without a word, and the user heard nothing at all until the final answer.
-      expect(result.instructions).toContain('acknowledgement');
       expect(result.instructions).toContain('silence');
+      // Said here and nowhere else. The agent prompt used to ask for the same line,
+      // and Jarvis obligingly delivered it twice.
+      expect(result.instructions).toContain('nowhere else');
       // The polling half of the contract has to survive the addition.
       expect(result.instructions).toContain('getNextInstructionsWorkflow');
     });
@@ -244,6 +246,21 @@ describe('Routing Workflows', () => {
       const second = await nextInstructions();
       expect(second.instructions).toContain('All tasks have completed');
       expect(second.completedTaskResults).toEqual([{ id: 'get-weather', result: 'Standup at 9am' }]);
+    });
+
+    it('points a finished request back at routing for whatever the user asks next', async () => {
+      useAgents(createMockAgent('calendar', { respond: () => 'A birthday' }));
+      usePlan({ id: 'calendar-check', agent: 'calendar', prompt: 'Get the calendar', dependsOn: [] });
+
+      await route('Check my calendar');
+      const report = await nextInstructions();
+
+      expect(report.instructions).toContain('All tasks have completed');
+      // Finishing one request is not finishing the conversation. Asked next to check
+      // the blinds and lights, Jarvis promised to look and called nothing — the last
+      // instruction of the loop had left it with no pointer back to the tool.
+      expect(report.instructions).toContain('routePromptWorkflow');
+      expect(report.instructions).toContain('not the conversation');
     });
 
     it('never reports the same task twice', async () => {

--- a/mcp/mastra/verticals/routing/workflows.ts
+++ b/mcp/mastra/verticals/routing/workflows.ts
@@ -109,19 +109,29 @@ const instructionsOutputSchema = z.object({
  */
 const INSTRUCTIONS = {
   async: 'The request is being processed in the background and will complete on its own. End the call now.',
-  // Queueing is the longest silence in the whole loop — planning the DAG and
-  // running the first wave both happen behind it — and it is the one step whose
-  // instructions never asked for a word to the user. Jarvis went straight from
-  // routing to polling without speaking, so the user heard nothing between
-  // asking and the final answer.
-  poll: 'The request is now being processed in the background. Before you call anything else, make sure the user has actually heard from you: if you have not spoken since he made the request, give him a brief acknowledgement now, because he is otherwise left sitting in silence while this runs. Then call getNextInstructionsWorkflow to check on the status and receive the next instructions.',
+  // Queueing hides the longest silence in the loop: planning the DAG and running
+  // the first wave both happen behind it. This is the only place the "I'm on it"
+  // line is specified. It was once asked for here *and* in the agent prompt, and
+  // Jarvis duly delivered both — "Let me check your calendar." then "I'm on it,
+  // sir." — so the prompt now stays out of it and this string is unconditional.
+  poll: 'The request is now being processed in the background. Say a short line in your own voice telling the user you are on it — under six words, spoken now, because he is otherwise left sitting in silence while this runs. This is the only such line he should hear, so give it here and nowhere else. Then call getNextInstructionsWorkflow to check on the status and receive the next instructions.',
   stillProcessing:
     'Still processing your request. Call getNextInstructionsWorkflow again to wait a bit longer for it to complete.',
   summarize: 'Summarize the new completed task results in a detailed manner.',
   acknowledge: 'Mention briefly that you have received the information in less than 5 words.',
 } as const;
 
-const ALL_TASKS_COMPLETED_INSTRUCTIONS = `All tasks have completed. ${INSTRUCTIONS.summarize}`;
+/**
+ * Finishing one request does not finish the conversation. Jarvis summarised a
+ * completed calendar lookup and then, asked to check the blinds and lights, promised
+ * to look and called nothing: the loop's last instruction left it holding no pointer
+ * back to the tool.
+ */
+const ALL_TASKS_COMPLETED_INSTRUCTIONS =
+  `All tasks have completed. ${INSTRUCTIONS.summarize} ` +
+  'That finishes this request, but not the conversation: if the user asks for anything further, ' +
+  'send it through routePromptWorkflow exactly as you did this one. Answering a later request from ' +
+  'memory, or promising to look and then calling nothing, leaves him with nothing at all.';
 
 /** How long a single poll may block before we tell Jarvis to call again. */
 const POLL_DEADLINE_MS = 15_000;


### PR DESCRIPTION
Two failures in one conversation.

## 1. The acknowledgement arrived twice

```
Agent: ...I'm not Charles, sir. I'm Jarvis. Let me check your calendar.
Agent: I'm on it, sir.
```

Both halves were asked for. The prompt still told Jarvis to acknowledge before routing, and `INSTRUCTIONS.poll` — added for the silence in #685 — asked for one too. Its *"if you have not spoken since he made the request"* hedge was meant to prevent exactly this, and didn't: **the model is in no position to judge whether what it just said counted.**

So the prompt stops asking. The line now lives in `INSTRUCTIONS.poll` and nowhere else, unconditionally, and the prompt instead says not to announce a lookup at all — the urge to say *"let me check"* is rephrased as the signal to call the tool rather than speak.

This follows your principle, and it's the right one: **anything that can live in the routing endpoint should.** An instruction arrives as data at the moment it's needed; a prompt rule has to be remembered across a whole conversation. One instruction, one source, no judgement call left to the model.

## 2. The second request was never routed

The conversation ends with:

```
User:  ...could you check if the blinds are lowered and if all the lights are off?
Agent: [amused] Ah, the classic "I forgot everything" defense. Let me check on
       those blinds and lights for you, sir.
```

Nothing called. That's the #681 failure again — but on the *second* request, which is why nothing caught it: **every eval to date was single-turn.**

Same principle applied: `ALL_TASKS_COMPLETED_INSTRUCTIONS` now says that finishing a request is not finishing the conversation, and anything further goes back through `routePromptWorkflow`. The loop's last instruction previously left Jarvis holding no pointer to the tool at all.

## Tests

**Mastra side** — the queue instructions must ask for the line *and claim it exclusively*; the completed instructions must point back at routing.

**ElevenLabs side** — a new multi-turn eval: route one request, note the tool count, make a second request, require the count to rise.

### One assertion had to be rewritten, not kept

The timing assertion from #685 demanded speech *before* the first tool call. That was correct when the prompt owned the acknowledgement and is **wrong now that the tool does** — the line legitimately lands after the call. It counts utterances instead: one means the user heard nothing until the answer itself. That's also sturdier, since it no longer races `agent_response` against `mcp_tool_call`.

`findLookupPromisesBeforeRouting` covers the duplicate directly — matching announcements Jarvis makes *before* routing while ignoring the identical words *after* it, where they came from the tool. Both rules are pinned down offline across 22 cases.

## Validation

- `bunx turbo typecheck` / `lint` — pass on both `elevenlabs` and `mcp`
- 49 offline elevenlabs tests — **49 pass, 0 fail**
- `mcp/mastra/verticals/routing/workflows.spec.ts` — **18 pass, 0 fail**

The conversation evals need live credentials and a tunnel, so CI's `build` check is the real verdict.

One thing to watch: with the prompt no longer asking for a pre-call acknowledgement, there is a genuine gap between the user's request and the tool's `I'm on it` — the `routePromptWorkflow` round trip, which includes DAG planning. That's the deliberate cost of removing the duplicate. If it reads as too long in practice, the fix is to make routing return its instructions sooner rather than to put the line back in the prompt.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jPnEZUvuTz3XtiTEyJwkh)_