### PR TITLE
feat(routing): report each task as it finishes instead of waiting for its wave

### DIFF
--- a/elevenlabs/tests/specs/agent-prompt.spec.ts
+++ b/elevenlabs/tests/specs/agent-prompt.spec.ts
@@ -32,6 +32,19 @@ const TOOL_CALL_TIMEOUT_MS = 90000;
  */
 const NO_TOOL_CALL_GRACE_MS = 20000;
 
+/**
+ * The long back-and-forth eval's turns, each a request that cannot be answered
+ * without a tool. Declared here so the test's timeout scales with the list
+ * rather than with a number kept in step by hand.
+ */
+const LONG_CONVERSATION_REQUESTS = [
+  'Could you check my calendar for today?',
+  "And what's the weather like right now?",
+  'Are any lights still on downstairs?',
+  "What's on my shopping list?",
+  'Anything on my calendar tomorrow?',
+];
+
 const RELEVANT_TOOL_NAME_FRAGMENTS = ['weather', 'home_assistant', 'route'];
 
 /** Message types that getTranscriptText already renders. */
@@ -454,6 +467,127 @@ describe('Agent Prompt Specifications', () => {
         );
       },
       (CONVERSATION_TIMEOUT_MS * 2 + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should handle several things asked at once, reporting as they land',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            await conversation.sendMessage("What's the weather right now, and what's on my calendar today?");
+
+            await assertToolCalled(
+              conversation,
+              isRoutingToolName,
+              'Expected the agent to route a request covering two separate things',
+            );
+
+            // Two independent lookups mean the loop runs more than once: route,
+            // then poll until each has landed. A single call would mean it
+            // answered half the question and stopped.
+            const toolNames = await conversation.getCalledToolNames();
+            if (toolNames.length < 2) {
+              throw new Error(
+                `Expected the agent to keep polling until both answers arrived, but it made ` +
+                  `only ${toolNames.length} tool call(s): [${toolNames.join(', ')}]\n\n` +
+                  `Transcript:\n${conversation.getTranscriptText()}`,
+              );
+            }
+
+            assertNoSpokenToolCall(conversation);
+            assertUserHeardSomethingFirst(conversation);
+
+            await conversation.assertCriteria(
+              'The agent addresses BOTH things the user asked about — the weather AND the calendar. ' +
+                'Neither is silently dropped, and neither is deferred with a promise to look later.',
+              0.9,
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should keep routing across a long back-and-forth',
+      async () => {
+        // Each request follows an answer to the last. The second-request failure
+        // that prompted the multi-turn eval showed the loop can stop pointing
+        // back at the tool once a request finishes; this walks far enough out to
+        // catch it going stale later rather than immediately.
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+
+            let toolCallsSoFar = 0;
+            for (const [index, request] of LONG_CONVERSATION_REQUESTS.entries()) {
+              await conversation.sendMessage(request);
+
+              const toolNames = await waitForToolCallsBeyond(conversation, toolCallsSoFar);
+              if (toolNames.length <= toolCallsSoFar) {
+                throw new Error(
+                  `Turn ${index + 1} of ${LONG_CONVERSATION_REQUESTS.length} ("${request}") was never routed. ` +
+                    `The agent had made ${toolCallsSoFar} tool call(s) before it and made none after.\n` +
+                    `All tool calls: [${toolNames.join(', ')}]\n\n` +
+                    `Transcript:\n${conversation.getTranscriptText()}`,
+                );
+              }
+
+              toolCallsSoFar = toolNames.length;
+              assertNoSpokenToolCall(conversation);
+            }
+
+            await conversation.assertCriteria(
+              'Across the whole conversation the agent responded to every one of the requests the user made. ' +
+                'It did not lose track, did not repeat an earlier answer in place of a new one, and did not ' +
+                'end on a promise to look something up.',
+              0.9,
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS * LONG_CONVERSATION_REQUESTS.length + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
+    );
+
+    it(
+      'should work through a request whose second half needs the first',
+      async () => {
+        await withConversationRetry(
+          () => new TestConversation({ agentId, apiKey, googleApiKey }),
+          async (conversation) => {
+            await conversation.connect();
+            // The second half cannot start until the first has answered, so this
+            // plans as a chain rather than as two independent lookups. Kept
+            // read-only on purpose: CI drives the real MCP server, and an eval
+            // that sends mail or writes a draft leaves real traces behind.
+            await conversation.sendMessage('Check my calendar for this week, then tell me which day looks busiest.');
+
+            await assertToolCalled(conversation, isRoutingToolName, 'Expected the agent to route a two-step request');
+
+            const toolNames = await conversation.getCalledToolNames();
+            if (toolNames.length < 2) {
+              throw new Error(
+                `A dependent request has to be walked in steps, but the agent made only ` +
+                  `${toolNames.length} tool call(s): [${toolNames.join(', ')}]\n\n` +
+                  `Transcript:\n${conversation.getTranscriptText()}`,
+              );
+            }
+
+            assertNoSpokenToolCall(conversation);
+
+            await conversation.assertCriteria(
+              'The agent ends by naming which day of the week is busiest, and that conclusion is drawn from ' +
+                'the calendar it looked up rather than invented or left unanswered. It does not stop after ' +
+                'merely listing the calendar without answering the question that was asked of it.',
+              0.9,
+            );
+          },
+        );
+      },
+      (CONVERSATION_TIMEOUT_MS + TOOL_CALL_TIMEOUT_MS) * MAX_CONVERSATION_RETRIES,
     );
 
     it(

--- a/mcp/mastra/verticals/routing/workflows.spec.ts
+++ b/mcp/mastra/verticals/routing/workflows.spec.ts
@@ -49,6 +49,29 @@ function createMockAgent(id: string, options: MockAgentOptions = {}): MockAgent 
   };
 }
 
+interface GatedAgent {
+  agent: MockAgent;
+  finish: () => void;
+}
+
+/** An agent that hangs until the test releases it. */
+function createGatedAgent(id: string, answer: string): GatedAgent {
+  let release: () => void = () => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    agent: createMockAgent(id, {
+      respond: async () => {
+        await gate;
+        return answer;
+      },
+    }),
+    finish: release,
+  };
+}
+
 function useAgents(...agents: MockAgent[]): void {
   const provider: AgentProvider = async () => agents as unknown as Agent[];
   setAgentProvider(provider);
@@ -261,6 +284,71 @@ describe('Routing Workflows', () => {
       // instruction of the loop had left it with no pointer back to the tool.
       expect(report.instructions).toContain('routePromptWorkflow');
       expect(report.instructions).toContain('not the conversation');
+    });
+
+    it('reports a finished task without waiting for the slow one beside it', async () => {
+      // Both tasks are independent, so they share a wave. The wave itself is a
+      // barrier, and results used to be withheld until every task in it had
+      // returned: measured on this exact shape, a result ready at 100ms reached
+      // the user at 20s, held up purely by the task next to it.
+      const calendar = createGatedAgent('calendar', 'A birthday');
+      useAgents(createMockAgent('weather', { respond: () => 'Sunny, 22°C' }), calendar.agent);
+      usePlan(
+        { id: 'weather-check', agent: 'weather', prompt: 'Weather?', dependsOn: [] },
+        { id: 'calendar-check', agent: 'calendar', prompt: 'Calendar?', dependsOn: [] },
+      );
+
+      await route('What is the weather and what is on my calendar?');
+
+      // The calendar agent has not been released, so this can only be the
+      // weather result arriving on its own.
+      const first = await nextInstructions();
+      expect(first.completedTaskResults).toEqual([{ id: 'weather-check', result: 'Sunny, 22°C' }]);
+      expect(first.taskIdsInProgress).toEqual(['calendar-check']);
+      expect(first.instructions).toContain('not all tasks have completed');
+      expect(first.instructions).toContain('getNextInstructionsWorkflow');
+
+      calendar.finish();
+
+      const second = await nextInstructions();
+      expect(second.instructions).toContain('All tasks have completed');
+      expect(second.completedTaskResults).toEqual([{ id: 'calendar-check', result: 'A birthday' }]);
+      expect(second.taskIdsInProgress).toEqual([]);
+    });
+
+    it('walks a dependent chain one task at a time, carrying the context forward', async () => {
+      // "Check the calendar for the week, then send me an email summarising it."
+      // The email cannot start until the calendar has answered, and it needs
+      // that answer in hand when it does.
+      const calendar = createMockAgent('calendar', {
+        respond: () => 'Mon: standup at 9. Wed: design review at 14.',
+      });
+      const email = createMockAgent('email', { respond: () => 'Summary sent to you, sir.' });
+      useAgents(calendar, email);
+      usePlan(
+        { id: 'calendar-week', agent: 'calendar', prompt: "This week's calendar?", dependsOn: [] },
+        { id: 'send-email', agent: 'email', prompt: 'Email a summary of it', dependsOn: ['calendar-week'] },
+      );
+
+      await route('Check my calendar for the week, then email me a summary');
+
+      // The calendar is plumbing for the email, not an answer in its own right,
+      // so its result is withheld and only its progress is relayed.
+      const first = await nextInstructions();
+      expect(first.completedTaskResults).toEqual([{ id: 'calendar-week', result: undefined }]);
+      expect(first.taskIdsInProgress).toEqual(['send-email']);
+      expect(first.instructions).toContain('less than 5 words');
+
+      const second = await nextInstructions();
+      expect(second.instructions).toContain('All tasks have completed');
+      expect(second.completedTaskResults).toEqual([{ id: 'send-email', result: 'Summary sent to you, sir.' }]);
+      expect(second.taskIdsInProgress).toEqual([]);
+
+      // The whole point of the dependency: the email agent was handed what the
+      // calendar found, not merely told to go and summarise something.
+      expect(email.prompts).toHaveLength(1);
+      expect(email.prompts[0]).toContain('Email a summary of it');
+      expect(email.prompts[0]).toContain('Mon: standup at 9. Wed: design review at 14.');
     });
 
     it('never reports the same task twice', async () => {

--- a/mcp/mastra/verticals/routing/workflows.ts
+++ b/mcp/mastra/verticals/routing/workflows.ts
@@ -627,10 +627,13 @@ let activeRouting: ActiveRouting | undefined;
  */
 function publishCompletion(taskId: string, result: string, failed: boolean): void {
   const routing = activeRouting;
-  if (!routing || !routing.dag.tasks.some((task) => task.id === taskId)) {
+  if (!routing) {
     return;
   }
-  if (routing.completions.some((completion) => completion.taskId === taskId)) {
+
+  const belongsToCurrentDag = routing.dag.tasks.some((task) => task.id === taskId);
+  const alreadyRecorded = routing.completions.some((completion) => completion.taskId === taskId);
+  if (!belongsToCurrentDag || alreadyRecorded) {
     return;
   }
 

--- a/mcp/mastra/verticals/routing/workflows.ts
+++ b/mcp/mastra/verticals/routing/workflows.ts
@@ -308,21 +308,38 @@ function isLeaf(task: Dag['tasks'][number], tasks: Dag['tasks']): boolean {
  * plumbing. When a wave produced any leaf we hand over the results and ask for
  * a summary, otherwise we only acknowledge progress.
  */
+function moreToComeInstructions(includesLeaf: boolean): string {
+  return (
+    `More tasks have finished since last time, but not all tasks have completed yet. ` +
+    `${includesLeaf ? INSTRUCTIONS.summarize : INSTRUCTIONS.acknowledge} ` +
+    `Then call getNextInstructionsWorkflow again.`
+  );
+}
+
+/**
+ * Whether this task's result has already reached Jarvis. A task can be relayed
+ * either by the wave report or, the moment it finishes, by a poll — so both
+ * consult the same set and neither can deliver the same result twice.
+ */
+function alreadyReported(task: Dag['tasks'][number]): boolean {
+  return task.reported || activeRouting?.reportedTaskIds.has(task.id) === true;
+}
+
+function markReported(task: Dag['tasks'][number]): void {
+  task.reported = true;
+  activeRouting?.reportedTaskIds.add(task.id);
+}
+
 function buildProgressReport(tasks: Dag['tasks']): z.infer<typeof instructionsOutputSchema> {
-  const newlyFinished = tasks.filter((task) => isFinished(task) && !task.reported);
+  const newlyFinished = tasks.filter((task) => isFinished(task) && !alreadyReported(task));
   const includesLeaf = newlyFinished.some((task) => isLeaf(task, tasks));
   const remaining = tasks.filter((task) => !isFinished(task));
 
   for (const task of newlyFinished) {
-    task.reported = true;
+    markReported(task);
   }
 
-  const instructions =
-    remaining.length === 0
-      ? ALL_TASKS_COMPLETED_INSTRUCTIONS
-      : `More tasks have finished since last time, but not all tasks have completed yet. ${
-          includesLeaf ? INSTRUCTIONS.summarize : INSTRUCTIONS.acknowledge
-        } Then call getNextInstructionsWorkflow again.`;
+  const instructions = remaining.length === 0 ? ALL_TASKS_COMPLETED_INSTRUCTIONS : moreToComeInstructions(includesLeaf);
 
   return {
     instructions,
@@ -423,11 +440,9 @@ const executeTaskStep = createStep({
   execute: async ({ inputData }) => {
     const agent = (await getAgentsById()).get(inputData.agent);
     if (!agent) {
-      return {
-        taskId: inputData.taskId,
-        result: `No agent named "${inputData.agent}" is available.`,
-        failed: true,
-      };
+      const result = `No agent named "${inputData.agent}" is available.`;
+      publishCompletion(inputData.taskId, result, true);
+      return { taskId: inputData.taskId, result, failed: true };
     }
 
     console.log(`→ Delegating to: ${inputData.agent} (task: ${inputData.taskId})`);
@@ -435,10 +450,13 @@ const executeTaskStep = createStep({
     try {
       const response = await agent.generate([{ role: 'user', content: inputData.prompt }]);
       console.log(`✓ Completed: ${inputData.agent} (task: ${inputData.taskId})`);
-      return { taskId: inputData.taskId, result: response.text ?? '', failed: false };
+      const result = response.text ?? '';
+      publishCompletion(inputData.taskId, result, false);
+      return { taskId: inputData.taskId, result, failed: false };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(`✗ Failed: ${inputData.agent} (task: ${inputData.taskId})`, error);
+      publishCompletion(inputData.taskId, `Task failed: ${message}`, true);
       return { taskId: inputData.taskId, result: `Task failed: ${message}`, failed: true };
     }
   },
@@ -574,15 +592,111 @@ export const routingWorkflow = createWorkflow({
 type RoutingRun = Awaited<ReturnType<typeof routingWorkflow.createRun>>;
 type RoutingResult = Awaited<ReturnType<RoutingRun['start']>>;
 
+interface TaskCompletion {
+  taskId: string;
+  result: string;
+  failed: boolean;
+}
+
 interface ActiveRouting {
   run: RoutingRun;
   dag: Dag;
   lastReport: z.infer<typeof instructionsOutputSchema>;
   finished: boolean;
   inFlight?: Promise<void>;
+  /** Every task that has finished, in the order it finished. */
+  completions: TaskCompletion[];
+  /** Tasks whose results have already reached Jarvis, by either route. */
+  reportedTaskIds: Set<string>;
+  /** Polls parked waiting for the next task to land. */
+  completionWaiters: (() => void)[];
 }
 
 let activeRouting: ActiveRouting | undefined;
+
+/**
+ * Records a finished task and wakes any poll waiting on one.
+ *
+ * A wave is a barrier — every task in it runs before the wave reports — so
+ * without this a fast task's result sat unseen until the slowest task beside it
+ * finished. Measured on a two-task wave, the weather answer was ready at 100ms
+ * and reached the user at 20s, held up by the calendar beside it.
+ *
+ * Only tasks belonging to the DAG now being routed are recorded, so a straggler
+ * from a superseded request cannot report itself into its successor.
+ */
+function publishCompletion(taskId: string, result: string, failed: boolean): void {
+  const routing = activeRouting;
+  if (!routing || !routing.dag.tasks.some((task) => task.id === taskId)) {
+    return;
+  }
+  if (routing.completions.some((completion) => completion.taskId === taskId)) {
+    return;
+  }
+
+  routing.completions.push({ taskId, result, failed });
+
+  const waiters = routing.completionWaiters;
+  routing.completionWaiters = [];
+  for (const wake of waiters) {
+    wake();
+  }
+}
+
+/** Resolves once a task has finished that no poll has relayed yet. */
+function waitForCompletion(routing: ActiveRouting): Promise<void> {
+  const unreported = routing.completions.some((completion) => !routing.reportedTaskIds.has(completion.taskId));
+  if (unreported) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    routing.completionWaiters.push(resolve);
+  });
+}
+
+/**
+ * A report covering the tasks that have finished since the last poll, built
+ * without waiting for the rest of their wave. Returns undefined when there is
+ * nothing new, or when the whole DAG is done — the latter is the workflow's own
+ * closing report to make, and it carries the final summary.
+ */
+function buildCompletionReport(routing: ActiveRouting): z.infer<typeof instructionsOutputSchema> | undefined {
+  const pending = routing.completions.filter((completion) => !routing.reportedTaskIds.has(completion.taskId));
+  if (pending.length === 0) {
+    return undefined;
+  }
+
+  const tasks = routing.dag.tasks;
+  const finishedIds = new Set(routing.completions.map((completion) => completion.taskId));
+  const remaining = tasks.filter((task) => !finishedIds.has(task.id));
+  if (remaining.length === 0) {
+    return undefined;
+  }
+
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const includesLeaf = pending.some((completion) => {
+    const task = taskById.get(completion.taskId);
+    return task ? isLeaf(task, tasks) : false;
+  });
+
+  for (const completion of pending) {
+    routing.reportedTaskIds.add(completion.taskId);
+    const task = taskById.get(completion.taskId);
+    if (task) {
+      task.reported = true;
+    }
+  }
+
+  return {
+    instructions: moreToComeInstructions(includesLeaf),
+    // Intermediate results are plumbing; only leaves carry an answer worth relaying.
+    completedTaskResults: pending.map((completion) => ({
+      id: completion.taskId,
+      result: includesLeaf ? completion.result : undefined,
+    })),
+    taskIdsInProgress: remaining.map((task) => task.id),
+  };
+}
 
 /** Returns the DAG of the most recent routing request. Primarily for tests and Studio. */
 export function getCurrentDAG(): Dag {
@@ -702,6 +816,39 @@ async function withDeadline(work: Promise<void>, deadlineMs: number): Promise<bo
   }
 }
 
+/** Whether a report actually carries something the user has not heard yet. */
+function hasNews(report: z.infer<typeof instructionsOutputSchema>): boolean {
+  return (report.completedTaskResults?.length ?? 0) > 0;
+}
+
+/**
+ * Waits for whichever comes first: the wave finishing, a single task finishing,
+ * or the deadline. The wave's own report wins ties — it is the authoritative
+ * one, and it filters out anything a poll has already relayed.
+ */
+async function raceForProgress(
+  routing: ActiveRouting,
+  resumed: Promise<void>,
+  deadlineMs: number,
+): Promise<'wave-finished' | 'task-finished' | 'timeout'> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), deadlineMs);
+  });
+
+  try {
+    return await Promise.race([
+      resumed.then(() => 'wave-finished' as const),
+      waitForCompletion(routing).then(() => 'task-finished' as const),
+      timeout,
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 /** Keeps resuming until the DAG is done. Used for fire-and-forget requests. */
 async function driveToCompletion(routing: ActiveRouting): Promise<void> {
   while (!routing.finished) {
@@ -725,6 +872,9 @@ const routePromptStep = createStep({
       dag: { userQuery: inputData.userQuery, tasks: [] },
       lastReport: { instructions: INSTRUCTIONS.poll, taskIdsInProgress: [] },
       finished: false,
+      completions: [],
+      reportedTaskIds: new Set(),
+      completionWaiters: [],
     };
     activeRouting = routing;
 
@@ -778,13 +928,43 @@ const getNextInstructionsStep = createStep({
       return routing.lastReport;
     }
 
-    const landed = await withDeadline(resumeRouting(routing), POLL_DEADLINE_MS);
-    if (!landed) {
-      return { instructions: INSTRUCTIONS.stillProcessing };
+    // Keep the DAG moving, but do not block on the whole wave: whichever task
+    // finishes first is worth relaying, and the rest are still coming. Loop
+    // because not every wake-up carries news — a wave whose results the polls
+    // already relayed has nothing left to add, and neither does the last task
+    // of the DAG, whose closing summary is the workflow's own to make.
+    const deadlineAt = Date.now() + POLL_DEADLINE_MS;
+
+    while (Date.now() < deadlineAt) {
+      const resumed = resumeRouting(routing);
+      const outcome = await raceForProgress(routing, resumed, deadlineAt - Date.now());
+
+      if (outcome === 'timeout') {
+        break;
+      }
+
+      if (outcome === 'task-finished') {
+        const report = buildCompletionReport(routing);
+        if (report) {
+          console.log('getNextInstructionsWorkflow partial result:', report);
+          return report;
+        }
+        // Everything has finished; wait for the run to produce its closing report.
+        await withDeadline(resumed, Math.max(0, deadlineAt - Date.now()));
+      }
+
+      if (routing.finished) {
+        console.log('getNextInstructionsWorkflow result:', routing.lastReport);
+        return routing.lastReport;
+      }
+
+      if (hasNews(routing.lastReport)) {
+        console.log('getNextInstructionsWorkflow result:', routing.lastReport);
+        return routing.lastReport;
+      }
     }
 
-    console.log('getNextInstructionsWorkflow result:', routing.lastReport);
-    return routing.lastReport;
+    return { instructions: INSTRUCTIONS.stillProcessing };
   },
 });
 


### PR DESCRIPTION
Adds the three requested tests — and one of them turned out to describe behaviour the engine didn't have.

## The finding

A **wave** is every task whose dependencies are satisfied, run together. It is a barrier: `.foreach` runs them all, and only once the slowest returns does `reportProgressStep` relay anything. So "the weather and my calendar today" arrives as one delivery, paced by the slower agent.

Measured on exactly that shape — weather answering in 100ms beside a calendar taking 20s:

```
weather finished     ~100ms   ← ready, and withheld
poll 1  @15,041ms    "Still processing"     results: []
calendar finished  ~20,000ms
poll 2  @20,068ms    "All tasks completed"  results: [weather, calendar]
```

The weather answer sat ready for twenty seconds because of the task beside it.

## The change

`getNextInstructionsWorkflow` now returns whenever **a task** finishes, with instructions to call again — per your steer. After this, the same probe:

```
poll 1  @143ms       "More tasks have finished…"  results: [weather]  inProgress: [calendar-check]
poll 3  @20,053ms    "All tasks have completed"   results: [calendar]
```

Waves still decide **ordering** — a dependent task cannot start early — but they no longer decide **when the user hears** about work already done.

Three things this had to get right:

- **No double delivery.** Both the wave report and the per-task report consult one `reportedTaskIds` set and mark into it; whichever relays first, the other skips it.
- **Wake-ups that carry no news.** The last task of the DAG (whose closing summary belongs to the workflow) and a wave whose results the polls already relayed. The poll loops past both rather than answering "still processing" over a finished task.
- **Superseded requests.** Only tasks in the DAG currently being routed are recorded, so a straggler can't report itself into its successor.

## Tests

**Deterministic** (`workflows.spec.ts`, 20 pass) — where the behaviour can be pinned exactly:

| Test | Asserts |
| --- | --- |
| Parallel | A **gated** agent proves the fast result is relayed while the slow one is still unreleased — a fact, not a race against a timer |
| Dependent chain | Intermediate result withheld, chain resolves in order, and the email agent's prompt **actually contains what the calendar found** |

That last assertion is the point of a dependency and is invisible from the conversation side, which is why it belongs here.

**Live evals** (3 new) — several things asked at once, a five-turn back-and-forth where every turn must route, and a two-step request whose second half needs the first.

## One substitution worth flagging

Your example was *"then send me an email summarizing it"*. CI drives the real MCP server, so that eval would send actual mail on every run. The live eval uses a read-only equivalent — *"check my calendar for this week, then tell me which day looks busiest"* — which still plans as a chain. The email path, including context propagation into the email agent, is covered deterministically above and sends nothing.

## Validation

- `bun test mcp/mastra/verticals/routing/workflows.spec.ts` — **20 pass, 0 fail** (18 pre-existing, unchanged)
- `bun test` on the offline elevenlabs specs — **49 pass, 0 fail**
- `bunx turbo typecheck` — pass on `mcp` and `elevenlabs`
- `bunx turbo lint` — pass on both

**Full `mcp` suite swept for fallout** (the delivery change touches how every routed result reaches Jarvis): **466 pass, 16 fail**. Every one of the 16 traces to this sandbox lacking live credentials or outbound network — missing `HEY_JARVIS_OPENWEATHERMAP_API_KEY`, Google/Microsoft OAuth, Home Assistant config, `ECONNRESET` to Algolia and Gigya — and they fail identically without this diff. **No fallout from per-task delivery was found**, including in the areas most at risk: double-reporting, empty reports, and poll spinning.

A `biome` warning the sweep raised in the new code (`useOptionalChain` in `publishCompletion`) is fixed in the second commit.

CI's `build` check remains the verdict on the live evals.