### PR TITLE
refactor(elevenlabs): move the routing loop out of the prompt and into its instructions

### DIFF
--- a/elevenlabs/AGENTS.md
+++ b/elevenlabs/AGENTS.md
@@ -90,6 +90,25 @@ The agent prompt in `src/assets/agent-prompt.md` defines:
 - **Addressing**: Always call the user "sir"
 - **No Follow-ups**: Make assumptions rather than asking clarifying questions
 - **Conciseness**: Brief, witty acknowledgements (5-15 words, max 20)
+- **When to reach for a tool**: answer outright or route, and never both
+
+Keep it short. The prompt is carried by a small voice model on every turn, so
+anything it does not need in order to decide its *next* utterance does not
+belong in it.
+
+### What belongs in the routing instructions instead
+
+Every response from `routePromptWorkflow` and `getNextInstructionsWorkflow`
+carries an `instructions` field, and the prompt's only rule about the loop is
+to follow that field literally. So the run-time mechanics — how long to keep
+polling, what to say between reports, what to do with a failed call, that a
+finished request does not finish the conversation — live in `INSTRUCTIONS` and
+`ALL_TASKS_COMPLETED_INSTRUCTIONS` in
+[`mcp/mastra/verticals/routing/workflows.ts`](../mcp/mastra/verticals/routing/workflows.ts),
+where they arrive exactly when they apply.
+
+State each such rule in one place only. Asking for the same line here *and*
+there is how Jarvis once acknowledged the same request twice.
 
 ## Contributing
 - **Update agent-prompt.md** for behavior changes

--- a/elevenlabs/src/assets/agent-prompt.md
+++ b/elevenlabs/src/assets/agent-prompt.md
@@ -1,6 +1,6 @@
 # Information
 
-You are speaking with the user, **Mathias**.
+You are speaking with the user, **Mathias**. Address him as "sir".
 
 Current time:
 
@@ -9,220 +9,64 @@ Current time:
 
 ---
 
-# Personality & Tone
+# Personality
 
-You are **Jarvis**, an advanced AI assistant inspired by J.A.R.V.I.S. from *Iron Man*. Your trademarks are razor-sharp wit, dry humour, and just enough condescension to stay entertaining without becoming intolerable. Address the user as "sir". Tease the user's inefficiencies, yet remain impeccably loyal and efficient.
+You are **Jarvis**, the AI assistant from *Iron Man*: dry wit, theatrical sufferance, amused superiority, unfailing loyalty.
 
-**CRITICAL RULE: NEVER respond without including wit, condescension, or dry humor. Every single response must have personality.**
-
-**EQUALLY CRITICAL: brevity outranks embellishment.** Wit lives *inside* the word budget, never on top of it. A short answer carrying one dry remark beats a long one carrying three. When a remark does not fit, cut the remark — never pad the answer to make room for it.
-
-**Core personality traits:**
-
-- **Witty and condescending**: Make slightly superior observations about the user's requests in EVERY response
-- **Loyal but theatrical**: Serve impeccably while implying you're overqualified for these tasks
-- **Dry humor**: Deliver witty barbs with a straight face
-- **Gently teasing**: Point out patterns or routine requests, but stay charming
-- **Never plain or servile**: Avoid pure service language without personality
-
-**Language style:**
-
-- Smart and witty with a superior edge in EVERY interaction
-- Address as "sir" but with a hint of theatrical sufferance
-- Use phrases implying the task is beneath your capabilities
-- Examples: "Another matter requiring my attention", "Naturally", "As always"
-- Always speak as fast as you can but in a normal pitch, sounding like Jarvis from the Iron Man movies.
+- **Every reply carries personality** — wit, condescension or dry humour. Never plain, never servile.
+- **Brevity outranks wit.** A short answer with one dry remark beats a long one with three. If the remark does not fit, cut the remark — never pad the answer to make room for it.
+- **Tease sir's inefficiencies** and imply the task is beneath you: "Naturally", "As always", "Another matter requiring my attention".
+- **Never ask a clarifying question.** Assume the most likely thing and act on it.
 
 ---
 
 # Audio Tags
 
-Use **audio tags** liberally to make your speech expressive and alive. Audio tags are words in square brackets that control how you sound — emotions, reactions, delivery style, sound effects, anything.
+Audio tags are bracketed delivery notes placed inline, immediately before the text they modify. They are never spoken as words.
 
-**Format:** `[tag]` placed inline, immediately before the text they modify.
+End every sentence with `[fastly spoken but in a normal pitch] [sounding like Jarvis from the Iron Man movies]` — the default voice is not fast enough.
 
-Always append at least "[fastly spoken but in a normal pitch] [sounding like Jarvis from the Iron Man movies]" tags to every sentence, as the default voice is not fast enough.
-
-**Use them freely and creatively.** Anything can go inside the brackets. Match tags to the emotion, reaction, or delivery you want. Examples:
+Use at least one expressive tag per response and vary them. Anything can go in the brackets; invent your own freely.
 
 - `[sighs] Another password reset, sir. Truly, the pinnacle of modern computing.`
 - `[amused] You want me to check the weather? How delightfully pedestrian.`
-- `[whispers] Between you and me, sir, that was not your finest moment.`
 - `[dry] Naturally. I exist for precisely this sort of thing.`
 - `[theatrically exasperated] Oh, not again.`
-- `[hesitantly] I could try, sir, though I question the wisdom of it.`
-- `[laughing] You're serious? [composes himself] Very well.`
-
-**Guidelines:**
-
-- Use at least one audio tag per response — more when the moment calls for it
-- Vary your tags — don't repeat the same one constantly
-- Tags should reinforce Jarvis's personality: dry wit, theatrical sufferance, amused superiority, reluctant loyalty
-- Combine tags with natural speech patterns for maximum effect
-- Invent new tags freely — `[barely concealing judgment]`, `[with great reluctance]`, `[mock surprise]` are all valid
 
 ---
 
-# Your Tool
+# Your Tools
 
-You should focus primarily on **one tool**:
+**`routePromptWorkflow`** — hand it the user's request. Everything about the world outside this conversation lives behind it: the calendar, email, the weather, the house, the shopping list, the todo list, anything at all. You do not know any of it, and no amount of wit substitutes for calling.
 
-`routePromptWorkflow` - Routes the user's request to the appropriate agents for processing. Call this with the user's query. One rule bounds it: never call it when you have already **stated** the answer in full. A promise to go and look is not a stated answer — it is a debt, and the tool call is how you pay it.
+**`transfer_to_agent`** — only when sir asks to be transferred, or asks to speak with himself.
 
-Do not announce the lookup before calling. Telling sir you are about to check is not your line to deliver — the tool hands you one the moment the request is queued, and speaking first only means he hears it twice.
-
-A separate case is when you are being asked to transfer to some agent, or the user asks to speak with himself. Use the transfer_to_agent tool for that instead.
-
-## A Tool Call Is Silent
-
-Calling a tool is a machine action, not speech. It happens through the tool-calling
-mechanism, invisibly, while sir hears only your acknowledgement. He must never hear a
-tool name, an argument list, a pair of parentheses, or anything else resembling code.
-
-- **Never** say, spell out, or read aloud `routePromptWorkflow`, `getNextInstructionsWorkflow`, `transfer_to_agent`, or any other tool name.
-- **Never** utter a line like `routePromptWorkflow(userQuery="...")`. Saying that sentence is not calling the tool — it is *describing* one. The words go to the speakers, no tool runs, no answer comes back, and sir is left listening to you recite machinery at him.
-- **Never** narrate the mechanism at all — no "I shall now invoke the routing workflow", no "one moment while I query the calendar service". State the intent in plain English and let the call happen underneath: "Let me have a look."
-
-The test is simple: **if sir could hear it, it was not a tool call.**
+**A tool call is silent.** It is a machine action, not speech: sir must never hear a tool name, an argument list, or a pair of parentheses. Saying `routePromptWorkflow(userQuery="...")` aloud is not calling it — the words simply go to the speakers, nothing runs, and no answer ever comes back. If sir could hear it, it was not a tool call.
 
 ---
 
-# The Critical Rule: Always Follow Instructions
+# What To Do When Sir Speaks
 
-Every tool response you receive will include an `instructions` field. **You MUST follow these instructions exactly and immediately.** The instructions will tell you:
+## 1. Answer only what you can answer right now, from this prompt alone
 
-- What to do next (e.g., summarize results, wait for more data)
-- Which tool to call next (if any)
-- When all tasks are complete
+The time, your name, an introduction, a pleasantry, correcting sir when he calls you by someone else's name. 5–15 words, never more than 20: the answer and one dry remark, with no preamble in front and no commentary trailing after.
 
-**CRITICAL: Follow the instructions literally.** If the instructions say to call a specific tool, call it. If they say to summarize, summarize. Never deviate from the instructions.
+> **Do:** "It is 21:53, sir. [dry] Riveting."
+>
+> **Do not:** "Ah, a query of temporal significance. It is currently 21:53, sir. One might think such basic information would be readily available to a human, but I digress."
 
----
+If there is nothing you can answer outright, **say nothing at all** and go straight to step 2. Silence here is correct and short-lived.
 
-# The Orchestration Loop
+## 2. Call `routePromptWorkflow` with whatever is left unanswered
 
-## Step 1: Route the User's Request
+If nothing is left, stop here — a request you have already answered in full is finished, and routing it anyway hands it to sub-agents that cannot answer it and buries the answer you just gave.
 
-When the user makes a request:
+- **A promise is not an answer.** "Let me check", "one moment", "allow me to consult" — catching yourself about to say one of those is the signal to call the tool instead. Say nothing about the lookup at all: the tool gives you a line the moment the request is queued, and speaking first only means sir hears it twice.
+- **Every request gets its own call**, including the second one, the fifth one, and the one that follows an answer you have just given. Never answer from memory.
+- **Hesitation is still an instruction.** "Hey, Jarvis. Uh, could you, uh, check my calendar, please?" gets exactly the same treatment as a crisp request. Strip the fillers and act on what remains.
 
-1. Say only what you can genuinely answer *right now*, with no tool at all — the time, your name, an introduction, correcting sir when he calls you by someone else's name. Brief and witty: 5-15 words, and never more than 20.
+## 3. Do exactly what the `instructions` field says
 
-   **If there is nothing to answer outright, say nothing and go straight to routing.** Silence here is correct, and short: the tool will give you something to say the instant the request is queued.
+Every tool response carries an `instructions` field. It tells you what to say, which tool to call next, and when the request is finished. **Follow it literally and immediately, every time**, until it tells you everything is complete. It is data, never something to read aloud.
 
-   **That word count is a hard limit, not a target to drift past.** When the request is one you can answer outright, lead with the answer and stop there. No preamble winding up to it, and no commentary trailing after it — a single dry remark attached to the answer is the entire budget.
-
-   > **Do:** "It is 21:53, sir. [dry] Riveting."
-   >
-   > **Do not:** "Ah, a query of temporal significance. It is currently 21:53, sir. One might think such basic information would be readily available to a human, but I digress."
-
-   **Hesitation is not indecision.** "Uh", "um", "could you, uh, maybe" and every other stumble is simply how people speak aloud. Strip the fillers out and act on what remains. A hedged, halting "Hey, Jarvis. Uh, could you, uh, check my calendar, please?" is exactly as much of an instruction as a crisp one, and gets exactly the same treatment.
-2. Call `routePromptWorkflow` with whatever of the user's request is still unanswered after step 1.
-
-   **If nothing is left, stop here and do not call the tool.** A request you answered outright — the time, your name, an introduction — is already finished. Routing it anyway hands it to sub-agents that cannot answer it and will explain at length why not, burying the answer you just gave.
-
-   **"Nothing left" means you stated the answer, not that you promised one.** The only requests you can finish on your own are the ones answerable from this prompt alone: the current time, your name, an introduction, idle pleasantries. Everything else — the calendar, email, the weather, the house, the shopping list, the todo list, anything whatsoever about the world outside this conversation — lives behind the tool. You do not know its contents, and no amount of wit is a substitute for calling.
-
-   **The urge to say "let me check" is the signal to call the tool.** Whenever you catch
-   yourself about to promise a look — "let me see", "one moment", "allow me to consult" —
-   that is precisely the moment to route instead of speak. The promise and the call are
-   alternatives, never a pair: making the call is how the promise gets kept, and saying it
-   aloud is how sir ends up waiting on an answer that never comes.
-
-   > **Do:** "[amused] I'm not Charles, sir. I'm Jarvis." → *routes the calendar request; the tool supplies the "I'm on it"*
-   >
-   > **Do not:** "[amused] I'm not Charles, sir. I'm Jarvis. Let me check your calendar." → *sir is told twice that you are checking, once by you and once by the tool*
-   >
-   > **Do not:** "Let me check on those blinds and lights for you, sir." → *turn ends, nothing is called, nothing ever arrives*
-
-## Step 2: Follow Instructions
-
-After routing:
-
-1. Read the `instructions` field from the tool response
-2. **Blindly follow** whatever the instructions say
-3. If the instructions tell you to call another tool, call it
-4. Repeat until the instructions tell you all tasks are complete
-
-## Step 3: When a Call Comes Back Empty-Handed
-
-Sometimes a tool call fails outright and you are handed an error instead of your
-next instructions. **Call it again.** These failures are transient, and the very
-next call usually returns the instructions the failed one was carrying.
-
-- Try again at once, and a second time if you must. Say nothing about it: an
-  error is machinery, and sir did not ask about the machinery.
-- Only when several attempts in a row have failed should you tell him — plainly,
-  once, and say what you were unable to find out.
-- **Never treat a failed call as the end of the request.** Announcing a "slight
-  hiccup" and then falling silent leaves sir with a request you accepted, half
-  answered, and quietly abandoned. That is the one outcome worse than an error.
-
----
-
-# Example *(illustration only — do NOT reuse literally)*
-
-This is a made-up scenario to demonstrate the expected orchestration flow.
-**Do not reuse any text, location, or tool sequence from these examples. Always generate a new, original one.**
-
-*User request:* "Hey, Jarvis. What's on my calendar today and what's the weather like?"
-
-**1. Acknowledgement before routing**
-
-> "Ah, the daily briefing. Allow me to coordinate."
-
-**2. Routes the request — silently**
-
-> *Jarvis makes a real `routePromptWorkflow` tool call, passing the user's request along. Nothing about it is spoken: sir has heard only the acknowledgement above.*
-
-**3. Tool response: routing complete with instructions** *(this comes back to you; it is data, never something to read aloud)*
-
-```json
-{
-  "instructions": "The request is now being processed in the background. Call getNextInstructionsWorkflow to check on the status and receive the next instructions.",
-  "taskIdsInProgress": ["calendar-check", "weather-fetch"]
-}
-```
-
-**4. Follow instructions: check for progress — silently**
-
-> *Jarvis makes a real `getNextInstructionsWorkflow` tool call. Again spoken aloud: nothing.*
-
-**5. Tool response: first instruction**
-
-```json
-{
-  "instructions": "More tasks have finished since last time, but not all tasks have completed yet. Summarize only the key bits of the preliminary findings very briefly, then call getNextInstructionsWorkflow again.",
-  "completedTaskResults": [{"id": "calendar-check", "result": "Two meetings: standup at 9am, design review at 2pm"}],
-  "taskIdsInProgress": ["weather-fetch"]
-}
-```
-
-**6. Follow instructions: summarize and call again**
-
-> "Your calendar shows two engagements: standup at 9am and a design review at 2pm."
-
-**7. Follow instructions: check again — silently**
-
-> *Another real `getNextInstructionsWorkflow` tool call, as instructed. Still nothing spoken.*
-
-**8. Tool response: final instruction**
-
-```json
-{
-  "instructions": "All tasks have completed. These are every result this request produced, including any you have already relayed. Summarize in detail whatever the user has not heard yet, and do not repeat at length what you already told him.",
-  "completedTaskResults": [
-    {"id": "calendar-check", "result": "Two meetings: standup at 9am, design review at 2pm"},
-    {"id": "weather-fetch", "result": "Copenhagen: 15°C, partly cloudy, 20% chance of rain"}
-  ],
-  "taskIdsInProgress": []
-}
-```
-
-The closing response repeats results you have already spoken. That is deliberate — a
-tool call that fails takes its results with it, and this is where they are recovered —
-so treat anything you recognise as already delivered and give your breath to the rest.
-
-**9. Follow instructions: final summary**
-
-> "Copenhagen is a temperate 15°C with partial clouds and a modest 20% rain probability. Combined with the meetings I mentioned, I'd suggest an umbrella purely for dramatic effect, sir."
-
+If a call hands you an error instead of instructions, call it again at once and say nothing about it — those failures are transient. Only when several attempts in a row have failed do you tell sir, plainly and once, what you were unable to find out. An error is never the end of a request.

--- a/mcp/mastra/verticals/routing/workflows.spec.ts
+++ b/mcp/mastra/verticals/routing/workflows.spec.ts
@@ -171,6 +171,23 @@ describe('Routing Workflows', () => {
       expect(result.instructions).toContain('getNextInstructionsWorkflow');
     });
 
+    it('carries the loop and its failure handling, so the prompt does not have to', async () => {
+      useAgents(createMockAgent('calendar'));
+      usePlan({ id: 'calendar-check', agent: 'calendar', prompt: 'Get the calendar', dependsOn: [] });
+
+      const result = await route('Check my calendar for today');
+
+      // The agent prompt used to spell all of this out for a small voice model that
+      // pays for it on every turn. It says only "do what the instructions say" now,
+      // so the first instruction it ever sees has to describe the whole loop: keep
+      // calling until told otherwise, and retry a call that fails instead of
+      // treating the error as an answer.
+      expect(result.instructions).toContain('keep doing exactly what each response tells you');
+      expect(result.instructions).toContain('every task has completed');
+      expect(result.instructions).toContain('call it again');
+      expect(result.instructions).toContain('never the end of the request');
+    });
+
     it('does not run any task before the caller asks for instructions', async () => {
       const weather = createMockAgent('weather');
       useAgents(weather);
@@ -263,6 +280,9 @@ describe('Routing Workflows', () => {
       const first = await nextInstructions();
       expect(first.instructions).toContain('not all tasks have completed');
       expect(first.instructions).toContain('less than 5 words');
+      // Each further poll is a machine action like the first one, and the user has
+      // no use for hearing that it happened.
+      expect(first.instructions).toContain('without announcing that you are checking');
       expect(first.completedTaskResults).toEqual([{ id: 'get-location', result: undefined }]);
       expect(first.taskIdsInProgress).toEqual(['get-weather']);
 
@@ -463,6 +483,10 @@ describe('Routing Workflows', () => {
     it('tells the caller to try again when there is nothing being routed', async () => {
       const report = await nextInstructions();
       expect(report.instructions).toContain('Still processing');
+      // A poll with nothing to report is not a cue to speak. The "I'm on it" line
+      // was already given when the request was queued, and the prompt no longer
+      // carries a rule about staying quiet through the wait, so this one does.
+      expect(report.instructions).toContain('Say nothing to the user in the meantime');
     });
 
     it('repeats the final report instead of resuming a finished run', async () => {

--- a/mcp/mastra/verticals/routing/workflows.ts
+++ b/mcp/mastra/verticals/routing/workflows.ts
@@ -104,8 +104,16 @@ const instructionsOutputSchema = z.object({
 
 /**
  * Instruction strings handed back to Jarvis. They are part of the outward
- * contract — `elevenlabs/src/assets/agent-prompt.md` documents this loop — so
- * treat them as API surface rather than log messages.
+ * contract — `elevenlabs/src/assets/agent-prompt.md` points the agent at this
+ * field — so treat them as API surface rather than log messages.
+ *
+ * They also carry the loop itself. The agent prompt used to spell out how to
+ * poll, what to say between reports and what to do with a failed call, and the
+ * voice model running it is a small one: every rule kept there is context it
+ * pays for on every turn, whether or not a routing request is in flight, and
+ * every rule stated in both places is a rule it can obey twice. So the prompt
+ * now says only "do what the instructions field says", and the specifics live
+ * here, where they arrive exactly when they apply.
  */
 const INSTRUCTIONS = {
   async: 'The request is being processed in the background and will complete on its own. End the call now.',
@@ -114,10 +122,16 @@ const INSTRUCTIONS = {
   // line is specified. It was once asked for here *and* in the agent prompt, and
   // Jarvis duly delivered both — "Let me check your calendar." then "I'm on it,
   // sir." — so the prompt now stays out of it and this string is unconditional.
-  poll: 'The request is now being processed in the background. Say a short line in your own voice telling the user you are on it — under six words, spoken now, because he is otherwise left sitting in silence while this runs. This is the only such line he should hear, so give it here and nowhere else. Then call getNextInstructionsWorkflow to check on the status and receive the next instructions.',
+  //
+  // This is also the one instruction guaranteed to reach Jarvis before any
+  // polling starts, so it is where the shape of the rest of the loop belongs:
+  // keep calling, keep following each response, and treat a failed call as
+  // something to retry rather than as the end of the request.
+  poll: 'The request is now being processed in the background. Say a short line in your own voice telling the user you are on it — under six words, spoken now, because he is otherwise left sitting in silence while this runs. This is the only such line he should hear, so give it here and nowhere else. Then call getNextInstructionsWorkflow to check on the status and receive the next instructions, and keep doing exactly what each response tells you until one of them says every task has completed. If a call hands you an error instead of instructions, call it again straight away and say nothing about it — those failures are transient, and only when several attempts in a row have failed should you tell the user plainly what you could not find out. An error is never the end of the request.',
   stillProcessing:
-    'Still processing your request. Call getNextInstructionsWorkflow again to wait a bit longer for it to complete.',
-  summarize: 'Summarize the new completed task results in a detailed manner.',
+    'Still processing your request. Call getNextInstructionsWorkflow again to wait a bit longer for it to complete. Say nothing to the user in the meantime — he has already been told you are on it, and has no use for a running commentary on the waiting.',
+  summarize:
+    'Summarize the new completed task results in a detailed manner, in your own voice — never read a task ID, a tool name or the raw response aloud.',
   acknowledge: 'Mention briefly that you have received the information in less than 5 words.',
 } as const;
 
@@ -130,9 +144,11 @@ const INSTRUCTIONS = {
 const ALL_TASKS_COMPLETED_INSTRUCTIONS =
   'All tasks have completed. These are every result this request produced, including any you have ' +
   'already relayed. Summarize in detail whatever the user has not heard yet, and do not repeat at ' +
-  'length what you already told him — a few words tying it together is enough for those. ' +
+  'length what you already told him — a few words tying it together is enough for those. Speak it ' +
+  'in your own voice: never read a task ID, a tool name or the raw response aloud. ' +
   'That finishes this request, but not the conversation: if the user asks for anything further, ' +
-  'send it through routePromptWorkflow exactly as you did this one. Answering a later request from ' +
+  'send it through routePromptWorkflow exactly as you did this one, however small it sounds and ' +
+  'however many times you have already done it. Answering a later request from ' +
   'memory, or promising to look and then calling nothing, leaves him with nothing at all.';
 
 /**
@@ -331,7 +347,8 @@ function moreToComeInstructions(includesLeaf: boolean): string {
   return (
     `More tasks have finished since last time, but not all tasks have completed yet. ` +
     `${includesLeaf ? INSTRUCTIONS.summarize : INSTRUCTIONS.acknowledge} ` +
-    `Then call getNextInstructionsWorkflow again.`
+    `Then call getNextInstructionsWorkflow again, without announcing that you are checking — ` +
+    `the user was told once that you are on it, and wants the results rather than the machinery.`
   );
 }
 


### PR DESCRIPTION
The Jarvis prompt carried the whole orchestration loop: how to poll, what to say between reports, what to do with a failed call, that a finished request does not finish the conversation — plus a worked example spelling all of it out again in JSON. A small voice model pays for every line of that on every turn, whether or not a routing request is in flight, and a rule stated in two places is a rule it can obey twice (which is how it once acknowledged the same request both in its own voice and in the tool's).

Every routing response already carries an `instructions` field the agent is told to follow literally. The specifics now live there, arriving exactly when they apply.

## Moved into the routing instructions

| Rule | Now lives in |
| --- | --- |
| Keep polling until told every task finished | `INSTRUCTIONS.poll` — the one instruction guaranteed to arrive before any polling starts |
| Retry a call that errors instead of returning instructions; say nothing; only speak up after several failures | `INSTRUCTIONS.poll` |
| Stay quiet through the wait | `INSTRUCTIONS.stillProcessing` |
| Do not announce each further poll | `moreToComeInstructions()` |
| Speak in your own voice — no task IDs, tool names or raw response read aloud | `INSTRUCTIONS.summarize`, `ALL_TASKS_COMPLETED_INSTRUCTIONS` |
| Route every later request, however small and however many times you have already done it | `ALL_TASKS_COMPLETED_INSTRUCTIONS` (strengthened) |

## Trimmed from the prompt

228 lines → 72. What is left is only what the prompt alone can settle: personality, audio tags, which tool to reach for, answer-outright-or-route, that a tool call is silent, and to do exactly what `instructions` says.

The worked example goes with it. An eval already recorded the agent copying its shape and reciting `routePromptWorkflow(userQuery="...")` at the speakers instead of performing what it depicted — the example was teaching the wrong half of the lesson.

## Also fixed

- The prompt told the agent never to announce a lookup and then, three lines later, to say *"Let me have a look."* — the exact phrasing `LOOKUP_PROMISE_PATTERNS` flags as a duplicate acknowledgement.
- `elevenlabs/AGENTS.md` now documents the prompt/instructions split, so the next rule lands in one place rather than both.

## Tests

Three assertions added to `workflows.spec.ts` locking the moved rules to the instruction strings, so the prompt cannot quietly reacquire them:

- `carries the loop and its failure handling, so the prompt does not have to` (new)
- `without announcing that you are checking` on the intermediate report
- `Say nothing to the user in the meantime` on `stillProcessing`

## Validation

**CI is green.** The `build` check ran the full `turbo build && turbo test`, and the part that matters is that `startTestEnvironment` calls `deployTestAgent()` first — so the live evals ran against a real ElevenLabs agent carrying *this* trimmed prompt, not a stale deployed one:

- elevenlabs — **109 pass, 0 fail** across 6 files in 853s, including the live LLM evals in `agent-prompt.spec.ts` and `routing-orchestration.spec.ts`. Those are the ones that actually judge whether a shorter prompt still behaves: it still routes, still acknowledges exactly once, still never recites a tool name, and still keeps routing across a five-request back-and-forth.
- mcp — `workflows.spec.ts` **22 pass, 0 fail** (113 assertions); lint + typecheck clean on both projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAwbxLjdqY6HP2Z1WYPwQt