### PR TITLE
ci: merge release please pull requests automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,60 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
+      # A release is cut either by the run that follows a human merging the
+      # release pull request, or — now that the pull request merges itself — by
+      # the tagging step further down in this same run.
+      release_created: ${{ steps.release.outputs.release_created || steps.tag.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name || steps.tag.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version || steps.tag.outputs.version }}
+      sha: ${{ steps.release.outputs.sha || steps.tag.outputs.sha }}
     steps:
       - name: Release using "Release Please"
         id: release
+        uses: googleapis/release-please-action@v4.4.1
+        with:
+          config-file: .github/release-please-config.json
+          manifest-file: .github/.release-please-manifest.json
+          target-branch: main
+
+      # A release pull request only restates commits that already went through
+      # review and CI on main, so it never needs a second human read. Hand it to
+      # GitHub's auto-merge, which lands it once branch protection is satisfied;
+      # auto-merge refuses a pull request that has nothing left to wait for, so
+      # fall back to merging it outright.
+      - name: Auto-merge the release pull request
+        id: merge
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_PRS: ${{ steps.release.outputs.prs }}
+        run: |
+          set -euo pipefail
+
+          merged=false
+          for number in $(jq -r '.[].number' <<<"$RELEASE_PRS"); do
+            echo "Merging release pull request #${number}"
+            gh pr merge "${number}" --squash --auto ||
+              gh pr merge "${number}" --squash
+
+            if [ "$(gh pr view "${number}" --json merged --jq '.merged')" = 'true' ]; then
+              merged=true
+            else
+              echo "::notice::Pull request #${number} is waiting on auto-merge. Its own merge starts no workflow run, so the release is tagged by the next run of this workflow."
+            fi
+          done
+
+          echo "merged=${merged}" >> "$GITHUB_OUTPUT"
+
+      # A merge performed with GITHUB_TOKEN does not start another workflow run,
+      # so the push that just landed on main never comes back around to tag the
+      # release. Run Release Please once more instead: it picks up the release
+      # pull request it has just seen merged and cuts the tags and GitHub
+      # releases here, in the same run, so `deploy` below has something to ship.
+      - name: Tag the merged release
+        id: tag
+        if: ${{ steps.merge.outputs.merged == 'true' }}
         uses: googleapis/release-please-action@v4.4.1
         with:
           config-file: .github/release-please-config.json
@@ -64,6 +112,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.1.0
         with:
+          # Check out the commit that was actually tagged. When the release
+          # pull request merged inside this same run, that commit is newer than
+          # the one this run started from, and only it carries the bumped
+          # versions the deploy publishes.
+          ref: ${{ needs.release.outputs.sha }}
           # The deploy runs project code and container builds; don't leave a
           # usable GitHub token behind in .git/config.
           persist-credentials: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,9 +144,12 @@ reviewable `initialize` target — never from a `postinstall`. Do not reintroduc
 
 ### GitHub Actions
 
-Every `uses:` is pinned to a full commit SHA with the version in a trailing
-comment (`uses: actions/checkout@d23441a… # v6.1.0`); tags are mutable and a
-retagged action runs with the workflow's token. Workflows default to
+Every `uses:` is pinned through `.github/workflows/actions.lock`, which records
+the commit each tag resolved to; GitHub runs that commit, so a retagged action
+cannot slip in under the workflow's token. Regenerate the lockfile with
+`gh actions-lock` after adding or bumping an action — never rewrite the `uses:`
+lines to bare SHAs by hand, which desynchronises them from the lockfile and
+makes GitHub reject every workflow in the repository. Workflows default to
 `permissions: {}` and opt into the minimum they need, and checkouts use
 `persist-credentials: false` so project code never inherits a usable token.
 
@@ -156,6 +159,27 @@ where a malicious pull request could read other jobs' secrets, poison the tool
 cache, or persist between runs. Registering one already requires repository
 admin; the CI check makes the other half explicit by rejecting any workflow that
 targets a runner we do not rent from GitHub.
+
+### Releases
+
+`Release` runs on every push to `main` and does the whole release itself — no
+human clicks merge. Release Please opens (or updates) the release pull request,
+the workflow immediately hands that pull request to GitHub's auto-merge, and
+falls back to merging it outright when auto-merge has nothing to wait for. The
+pull request is safe to merge unattended: it only restates commits that already
+passed review and CI on `main`, plus the version bumps and changelog entries
+derived from them.
+
+Merging it is not the end of the run, because a merge performed with
+`GITHUB_TOKEN` does not start another workflow run. So the same run invokes
+Release Please a second time to tag the release it just merged, and `deploy`
+checks out that tagged commit (`needs.release.outputs.sha`) rather than the
+commit the run started from — only the tagged commit carries the bumped
+versions. If auto-merge does park the pull request instead of merging it, the
+release is tagged by the next run of the workflow, and the run log says so.
+
+To hold a release back, hold the commits back: anything that lands on `main`
+ships on the next run.
 
 ## 1Password Authentication
 


### PR DESCRIPTION
The release pull request only restates commits that already passed review and CI on `main`, so waiting for a human to click merge just delays the release. `Release` now merges it itself.

## What changed

- **Auto-merge the release pull request** — a new step hands each pull request from `steps.release.outputs.prs` to GitHub's auto-merge (`gh pr merge --squash --auto`), falling back to a plain squash merge when auto-merge refuses because there is nothing left to wait for. Uses the `gh` CLI already on the runner, so `actions.lock` is unchanged.
- **Tag the merged release** — a merge performed with `GITHUB_TOKEN` starts no workflow run, so the push it creates would never come back around to tag the release. The same run therefore invokes Release Please a second time; it sees the merged pull request and cuts the tags and GitHub releases in place.
- **Job outputs** now come from whichever step created the release (`steps.release.* || steps.tag.*`), and expose `sha`.
- **`deploy` checks out `needs.release.outputs.sha`** — the tagged commit. When the release pull request merged inside this same run, that commit is newer than the one the run started from, and only it carries the bumped versions the deploy publishes. When a human merges the pull request instead, `sha` is the commit the run already started from, so the behaviour is unchanged.
- **AGENTS.md** gains a `Releases` section describing the flow, and its stale claim that every `uses:` is pinned to an inline commit SHA is corrected — pinning has lived in `actions.lock` since the inline SHAs desynchronised the lockfile and broke every workflow.

## Behaviour

Every push to `main` now releases and deploys on its own. To hold a release back, hold the commits back.

## One thing to check before merging

A release pull request can never get a `build` check: it is created by `GITHUB_TOKEN`, and GitHub refuses to start workflow runs for it. The evidence is on the branch itself — every `CI` run on `release-please--branches--main` (e.g. runs `32558698281`, `32490746701`, `32458170413`) ends in `startup_failure` before any job begins, and #690 accordingly merged with zero check runs.

So if `build` is a **required** status check on `main`, auto-merge on the release pull request waits on a check that will never arrive. In that case this step's fallback merge is refused by branch protection too, and the run fails loudly rather than releasing silently — visible, but not merged. Making this work under required checks needs the release branch exempted from the rule.

If `build` is not required (which is what #690 merging with no checks suggests), auto-merge declines the clean pull request, the fallback merges it, and the tagging step runs in the same job.

## Validation

- `bash ./.scripts/check-supply-chain.sh` passes (actions lockfile, hosted runners, no non-Bun invocations).
- Workflow YAML parses; the merge step's script passes `bash -n` and was exercised against a stubbed `gh` for all three paths: auto-merge enabled but unmerged (`merged=false`, notice logged, tagging skipped), auto-merge refused then merged directly (`merged=true`, tagging runs), and both blocked (step fails loudly rather than releasing silently).

No project code changed, so no build or test run applies.