### PR TITLE
fix(config): spell the release please changelog key so it takes effect

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,7 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
-  "changelog-types": [
+  "changelog-sections": [
     { "type": "feat", "section": "Features", "hidden": false },
     { "type": "fix", "section": "Bug Fixes", "hidden": false },
     { "type": "perf", "section": "Performance Improvements", "hidden": false },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,18 @@ release is tagged by the next run of the workflow, and the run log says so.
 To hold a release back, hold the commits back: anything that lands on `main`
 ships on the next run.
 
+What counts as releasable is `changelog-sections` in
+`.github/release-please-config.json`: `feat`, `fix`, `perf`, `refactor` and
+`docs` cut a release, and everything else — `test`, `build`, `ci`, `chore` —
+lands on `main` without one. A batch made up only of those types produces no
+release pull request at all, and the run says `No user facing commits found
+since <sha> - skipping`. That is the expected outcome, not a broken workflow.
+
+The config is checked against Release Please's schema through its `$schema`
+key, which is worth keeping: the key was previously spelled `changelog-types`,
+which the schema does not define, so the whole block was silently ignored and
+`refactor` and `docs` commits never released.
+
 ## 1Password Authentication
 
 This project uses **1Password CLI** for secure environment variable management.


### PR DESCRIPTION
Release pull requests stopped appearing. The cause is not the auto-merge change in #695 — it is a key name in `.github/release-please-config.json` that has never been read.

## What is happening

Every commit on `main` since the 1.13.0 release is a type Release Please does not treat as user facing:

| Commit | Type |
| --- | --- |
| #691 | `test` |
| #692 | `build` |
| #693 | `test` |
| #694 | `refactor` |
| #695 | `ci` |

So the run skips, once per configured path:

```
✔ Considering: 11 commits
✔ No user facing commits found since 80dc61df4288cbc02a9bb81c211412247757bbcf - skipping
```

`refactor` is on that list only because the config's intent never took effect. The block was declared under **`changelog-types`**, which is not a property Release Please's schema defines — and that schema sets `additionalProperties: false`, so the key was dropped and the built-in defaults applied instead. Under the defaults, `refactor` and `docs` are hidden, a batch of only hidden types builds empty release notes, and an empty changelog is exactly what "no user facing commits" means.

The repository's own changelogs confirm it has always been this way: **162** `Features`/`Bug Fixes` sections, and **zero** `Code Refactoring` or `Documentation` sections, in a repository that has been landing `refactor` commits for months.

## What changed

- **`changelog-types` → `changelog-sections`**, the property the schema actually defines. `refactor` and `docs` commits become releasable, as the config always said they should be, and get their own changelog sections.
- **Added `$schema`** pointing at Release Please's config schema, so the next misspelled key is flagged in the editor instead of silently ignored — `additionalProperties: false` means the schema catches exactly this class of mistake.
- **AGENTS.md** now states which commit types cut a release, and that a `test`/`build`/`ci`-only batch producing no release pull request is the expected outcome rather than a broken workflow.

## Effect

`refactor` and `docs` commits will start cutting patch releases. Combined with #695, they will also merge and deploy on their own — so this makes releases more frequent, which is what the config asked for. If that is not wanted for `docs`, flip that one entry to `"hidden": true` and it stops being releasable again.

This commit is itself a `fix`, so merging it produces the first release pull request since 1.13.0 — which is also the first live exercise of the auto-merge path from #695.

## Validation

- Config parses as JSON; every top-level key now validates against the fetched Release Please schema (`additionalProperties: false`, unknown keys: none). Before this change, `changelog-types` was the one unknown key.
- `bash ./.scripts/check-supply-chain.sh` passes.

Not verified end to end: cutting an actual release pull request needs a token and would create one against this repository, so the behaviour change rests on the schema and the changelog evidence above rather than a dry run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdQsC9ntaH2qA53jM8TM2g)_