### PR TITLE
fix(ci): merge the release pull request instead of parking on a check that never runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,39 +40,60 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4.4.1
         with:
+          # Falls back to GITHUB_TOKEN, whose pull requests never get checks.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
           target-branch: main
 
       # A release pull request only restates commits that already went through
-      # review and CI on main, so it never needs a second human read. Hand it to
-      # GitHub's auto-merge, which lands it once branch protection is satisfied;
-      # auto-merge refuses a pull request that has nothing left to wait for, so
-      # fall back to merging it outright.
+      # review and CI on main, so it never needs a second human read.
       - name: Auto-merge the release pull request
         id: merge
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_PRS: ${{ steps.release.outputs.prs }}
         run: |
           set -euo pipefail
 
           merged=false
+          blocked=false
           for number in $(jq -r '.[].number' <<<"$RELEASE_PRS"); do
             echo "Merging release pull request #${number}"
-            gh pr merge "${number}" --squash --auto ||
-              gh pr merge "${number}" --squash
 
-            if [ "$(gh pr view "${number}" --json merged --jq '.merged')" = 'true' ]; then
+            # Merge it outright first. Branch protection still applies — a token
+            # cannot merge past a rule it does not satisfy — so this lands only
+            # what is already allowed to land, and it keeps the tagging step
+            # below inside this same run.
+            if gh pr merge "${number}" --squash; then
               merged=true
+              continue
+            fi
+
+            # Something still gates the merge, so leave auto-merge armed: the
+            # release then lands by itself the moment that clears.
+            gh pr merge "${number}" --squash --auto || true
+
+            # Whether that is worth waiting for depends on who opened the pull
+            # request. GitHub starts no workflow run for one opened with
+            # GITHUB_TOKEN, so a required check on it never reports and
+            # auto-merge waits on it forever — a release going nowhere behind a
+            # green run. Any other author gets real checks, and waiting is
+            # exactly right.
+            if [ "$(gh pr view "${number}" --json author --jq '.author.login')" = 'github-actions' ]; then
+              blocked=true
+              echo "::error::Release pull request #${number} cannot merge itself. It was opened with GITHUB_TOKEN, so no workflow runs against it and any required check stays pending forever. Give Release Please a token of its own in the RELEASE_PLEASE_TOKEN secret, or exempt release-please--branches--main from the rule that blocks it."
             else
-              echo "::notice::Pull request #${number} is waiting on auto-merge. Its own merge starts no workflow run, so the release is tagged by the next run of this workflow."
+              echo "::notice::Release pull request #${number} is waiting on auto-merge, and lands once its checks pass."
             fi
           done
 
           echo "merged=${merged}" >> "$GITHUB_OUTPUT"
+
+          # Fail the run rather than let a stuck release look like a finished one.
+          [ "${blocked}" = false ]
 
       # A merge performed with GITHUB_TOKEN does not start another workflow run,
       # so the push that just landed on main never comes back around to tag the
@@ -84,6 +105,8 @@ jobs:
         if: ${{ steps.merge.outputs.merged == 'true' }}
         uses: googleapis/release-please-action@v4.4.1
         with:
+          # Falls back to GITHUB_TOKEN, whose pull requests never get checks.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
           target-branch: main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,19 +164,36 @@ targets a runner we do not rent from GitHub.
 
 `Release` runs on every push to `main` and does the whole release itself — no
 human clicks merge. Release Please opens (or updates) the release pull request,
-the workflow immediately hands that pull request to GitHub's auto-merge, and
-falls back to merging it outright when auto-merge has nothing to wait for. The
-pull request is safe to merge unattended: it only restates commits that already
-passed review and CI on `main`, plus the version bumps and changelog entries
-derived from them.
+and the workflow merges it: outright if nothing gates it, otherwise by arming
+auto-merge so it lands the moment whatever gates it clears. The pull request is
+safe to merge unattended: it only restates commits that already passed review
+and CI on `main`, plus the version bumps and changelog entries derived from
+them.
 
 Merging it is not the end of the run, because a merge performed with
 `GITHUB_TOKEN` does not start another workflow run. So the same run invokes
 Release Please a second time to tag the release it just merged, and `deploy`
 checks out that tagged commit (`needs.release.outputs.sha`) rather than the
 commit the run started from — only the tagged commit carries the bumped
-versions. If auto-merge does park the pull request instead of merging it, the
-release is tagged by the next run of the workflow, and the run log says so.
+versions.
+
+#### The release pull request needs a token of its own
+
+GitHub starts no workflow run for anything `GITHUB_TOKEN` did, and that
+includes opening the release pull request: its `CI` run is recorded as a
+`startup_failure` before any job begins, and no check ever appears on it. If
+`build` is a required check on `main`, auto-merge then waits on a check that
+can never report, and the release sits there forever — which is exactly what
+happened to #697.
+
+So set `RELEASE_PLEASE_TOKEN` to a token that is not `GITHUB_TOKEN` (a personal
+access token or a GitHub App installation token with `contents: write` and
+`pull-requests: write`). Release Please opens the pull request as that identity,
+CI runs on it for real, auto-merge lands it once green, and the merge starts the
+run that tags the release. Without that secret the workflow falls back to
+`GITHUB_TOKEN` and fails the run with the reason rather than parking quietly —
+the other way out is to exempt `release-please--branches--main` from the rule
+that blocks it.
 
 To hold a release back, hold the commits back: anything that lands on `main`
 ships on the next run.


### PR DESCRIPTION
#697 sat unmerged with auto-merge armed and nothing able to report into it. Two separate causes, both in the step added by #695.

## Why #697 never merged

The step armed auto-merge **first**, and only merged outright if arming failed:

```
gh pr merge "${number}" --squash --auto || gh pr merge "${number}" --squash
```

Arming succeeded, so the outright merge never ran — and waiting was hopeless. GitHub starts no workflow run for anything `GITHUB_TOKEN` did, including opening the release pull request: its `CI` run is recorded as `startup_failure` before any job begins (runs `32558698281`, `32490746701`, `32458170413`), and no check ever appears. #697's combined status was `pending` with **zero** statuses reported, `mergeable_state: blocked`, so auto-merge was waiting on a check that could never report.

Merging outright is now the first attempt. Branch protection still applies — a token cannot merge past a rule it does not satisfy — so this lands only what is already allowed to land, and it keeps tagging inside the same run.

## The second bug: `--json merged` is not a field

```
if [ "$(gh pr view "${number}" --json merged --jq '.merged')" = 'true' ]; then
```

`merged` is not a field `gh pr view --json` defines. The call exited non-zero and dumped its list of valid fields into the run log (visible in job `97328779208`), so `merged` was **always** false — meaning even a successful fallback merge would have skipped the tagging step and left the release untagged. The exit status of the merge itself now decides, so the broken call is gone rather than corrected.

## `RELEASE_PLEASE_TOKEN`

Both Release Please invocations and `gh` now use `${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}`. Set that secret to a personal access token or GitHub App installation token (`contents: write`, `pull-requests: write`) and the release pull request is opened as that identity, so CI runs on it for real, auto-merge lands it on green, and the merge starts the run that tags the release.

Until it is set, nothing changes except honesty: a release pull request that cannot merge itself now **fails the run** with the reason, instead of leaving a stuck release behind a green run.

## Validation

Script passes `bash -n`; exercised against a stubbed `gh` (whose `--json` stub rejects unknown fields exactly as real `gh` does) across four paths:

| Scenario | Result |
| --- | --- |
| Nothing gates the merge | merges now, `merged=true`, tagging runs, exit 0 |
| Blocked, opened by `github-actions` | arms auto-merge, `::error::` naming the fix, exit 1 |
| Blocked, opened by a real identity | arms auto-merge, notice, exit 0 — waiting is correct here |
| Blocked and auto-merge unavailable, real identity | notice, exit 0 |

`bash ./.scripts/check-supply-chain.sh` passes; workflow YAML parses; `actions.lock` unchanged (no new actions).

## Note on #697 itself

I merged it manually so 1.13.1 was not left stranded — that merge did start the `Release` run that tags and deploys it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdQsC9ntaH2qA53jM8TM2g)_